### PR TITLE
Rebuild Django admin templates with Flowbite styling

### DIFF
--- a/flowbite_admin/templates/admin/base_site.html
+++ b/flowbite_admin/templates/admin/base_site.html
@@ -1,2 +1,227 @@
-<!-- base template -->
-{% block content %}{% endblock %}
+{% extends "admin/base.html" %}
+{% load i18n static %}
+
+{% block extrastyle %}
+  {{ block.super }}
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/tailwindcss/2.2.19/tailwind.min.css" integrity="sha512-+RdY+VqxGNzcRCjSc5MiNmiRC6L0H944kaW1YHlzTH0jzZMfjNV8iPBUFeCFGXFZ8iDSHPsuacF2nwLxgL8v2Q==" crossorigin="anonymous" referrerpolicy="no-referrer">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flowbite/2.3.0/flowbite.min.css" integrity="sha512-9wDG+TfLZNVVRFlE0YyqS/fWznuaCG2lLBVmOAXoJ1Bs8LojRxurx8WcN6iYG3PaY5E9O+V1YxDCEV4VpWw2NQ==" crossorigin="anonymous" referrerpolicy="no-referrer">
+  <style>
+    :root {
+      color-scheme: light dark;
+    }
+    body {
+      background-color: transparent;
+    }
+  </style>
+{% endblock %}
+
+{% block extrahead %}
+  {{ block.super }}
+  <script>
+    (function () {
+      const colorTheme = localStorage.getItem('color-theme');
+      const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+      if (colorTheme === 'dark' || (!colorTheme && prefersDark)) {
+        document.documentElement.classList.add('dark');
+      } else {
+        document.documentElement.classList.remove('dark');
+      }
+    })();
+  </script>
+{% endblock %}
+
+{% block bodyclass %}{{ block.super }} bg-gray-50 dark:bg-gray-900{% endblock %}
+
+{% block header %}
+<header class="fixed inset-x-0 top-0 z-30 border-b border-gray-200 bg-white/95 backdrop-blur dark:border-gray-700 dark:bg-gray-900/95">
+  <div class="mx-auto flex max-w-full items-center justify-between px-4 py-3 sm:px-6 lg:px-8">
+    <div class="flex items-center gap-3">
+      <button type="button" class="inline-flex items-center rounded-lg border border-gray-200 p-2 text-sm text-gray-500 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-800" data-drawer-target="logo-sidebar" data-drawer-toggle="logo-sidebar" aria-controls="logo-sidebar" aria-label="{% translate 'Toggle navigation' %}">
+        <svg class="h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4 6h16M4 12h16M4 18h16" />
+        </svg>
+      </button>
+      <a href="{% url 'admin:index' %}" class="flex items-center gap-2 text-xl font-semibold text-gray-900 dark:text-white">
+        <span class="inline-flex h-10 w-10 items-center justify-center rounded-lg bg-blue-600 text-lg font-bold text-white">{% firstof site_header 'FB' %}</span>
+        <span class="hidden md:inline">{% firstof site_title site_header _('Flowbite Admin') %}</span>
+      </a>
+    </div>
+    <div class="flex items-center gap-2">
+      <button id="theme-toggle" type="button" class="inline-flex items-center rounded-lg border border-gray-200 p-2 text-sm text-gray-500 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-800" aria-label="{% translate 'Toggle dark mode' %}">
+        <svg id="theme-toggle-dark-icon" class="hidden h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
+          <path d="M17.293 13.293a8 8 0 11-10.586-10.586 8.001 8.001 0 1010.586 10.586z" />
+        </svg>
+        <svg id="theme-toggle-light-icon" class="hidden h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
+          <path d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4.22 2.03a1 1 0 011.414 0l.708.707a1 1 0 11-1.414 1.415l-.708-.708a1 1 0 010-1.414zM17 9a1 1 0 100 2h1a1 1 0 100-2h-1zm-7 7a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zm-7-7a1 1 0 100 2H2a1 1 0 100-2h1zm1.636-5.657a1 1 0 011.414 0l.708.707A1 1 0 016.343 5.5l-.707-.708a1 1 0 010-1.414zM5.5 15.657a1 1 0 010 1.415l-.707.707a1 1 0 11-1.415-1.414l.708-.708a1 1 0 011.414 0zM15.657 14.5a1 1 0 011.414 0l.708.707a1 1 0 11-1.414 1.415l-.708-.708a1 1 0 010-1.414z" />
+        </svg>
+      </button>
+      {% if has_permission %}
+      <div class="hidden text-right text-sm sm:block">
+        <p class="font-medium text-gray-900 dark:text-gray-100">{% block welcome-msg %}{% translate 'Welcome,' %} <strong>{% firstof user.get_short_name user.get_username %}</strong>{% endblock %}</p>
+        <div class="mt-1 space-x-2 text-xs text-gray-500 dark:text-gray-400">
+          {% block userlinks %}
+            {% if site_url %}
+              <a class="hover:text-blue-600" href="{{ site_url }}">{% translate 'View site' %}</a>
+            {% endif %}
+            {% if user.is_active and user.is_staff %}
+              {% url 'django-admindocs-docroot' as docsroot %}
+              {% if docsroot %}
+                <span aria-hidden="true">·</span>
+                <a class="hover:text-blue-600" href="{{ docsroot }}">{% translate 'Documentation' %}</a>
+              {% endif %}
+            {% endif %}
+            {% if user.has_usable_password %}
+              <span aria-hidden="true">·</span>
+              <a class="hover:text-blue-600" href="{% url 'admin:password_change' %}">{% translate 'Change password' %}</a>
+            {% endif %}
+            <span aria-hidden="true">·</span>
+            <form id="logout-form" method="post" action="{% url 'admin:logout' %}" class="inline">
+              {% csrf_token %}
+              <button type="submit" class="font-medium text-blue-600 hover:text-blue-500 focus:outline-none dark:text-blue-400">{% translate 'Log out' %}</button>
+            </form>
+          {% endblock %}
+        </div>
+      </div>
+      {% endif %}
+    </div>
+  </div>
+</header>
+{% endblock %}
+
+{% block nav-breadcrumbs %}
+  <nav class="mt-20 px-4 sm:ml-64 sm:px-8" aria-label="{% translate 'Breadcrumbs' %}">
+    {% block breadcrumbs %}
+      <ol class="flex flex-wrap items-center gap-2 text-sm text-gray-500 dark:text-gray-400">
+        <li>
+          <a class="inline-flex items-center gap-1 rounded-lg px-3 py-1 font-medium text-gray-600 hover:bg-gray-100 hover:text-gray-900 dark:text-gray-300 dark:hover:bg-gray-800 dark:hover:text-white" href="{% url 'admin:index' %}">
+            <svg class="h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0h6" />
+            </svg>
+            {% translate 'Home' %}
+          </a>
+        </li>
+        {% if title %}
+        <li aria-hidden="true" class="text-gray-400">/</li>
+        <li class="font-semibold text-gray-700 dark:text-gray-200">{{ title }}</li>
+        {% endif %}
+      </ol>
+    {% endblock %}
+  </nav>
+{% endblock %}
+
+{% block nav-sidebar %}
+<aside id="logo-sidebar" class="fixed left-0 top-0 z-40 h-screen w-64 -translate-x-full border-r border-gray-200 bg-white pt-20 transition-transform dark:border-gray-700 dark:bg-gray-900 sm:translate-x-0" aria-label="{% translate 'Sidebar' %}">
+  <div class="h-full overflow-y-auto px-4 pb-6">
+    <div class="mb-6 hidden sm:block">
+      <p class="text-xs font-semibold uppercase tracking-widest text-gray-400 dark:text-gray-500">{% translate 'Navigation' %}</p>
+    </div>
+    <ul class="space-y-1 text-sm font-medium">
+      {% with apps=app_list|default:available_apps %}
+        {% if apps %}
+          {% for app in apps %}
+            <li>
+              <div class="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">{{ app.name }}</div>
+              <ul class="mt-2 space-y-1">
+                {% for model in app.models %}
+                  <li>
+                    {% if model.admin_url %}
+                      <a href="{{ model.admin_url }}" class="flex items-center justify-between rounded-lg px-3 py-2 text-gray-600 transition hover:bg-blue-50 hover:text-blue-700 dark:text-gray-300 dark:hover:bg-gray-800 dark:hover:text-white">
+                        <span>{{ model.name }}</span>
+                        {% if model.add_url %}
+                          <span class="text-xs font-semibold text-blue-600 dark:text-blue-400" title="{% translate 'Add' %}">+</span>
+                        {% endif %}
+                      </a>
+                    {% else %}
+                      <span class="flex items-center rounded-lg px-3 py-2 text-gray-400 dark:text-gray-500">{{ model.name }}</span>
+                    {% endif %}
+                  </li>
+                {% endfor %}
+              </ul>
+            </li>
+          {% endfor %}
+        {% else %}
+          <li class="rounded-lg bg-gray-50 px-3 py-4 text-sm text-gray-500 dark:bg-gray-800/50 dark:text-gray-400">{% translate 'You don\'t have permission to view or edit anything.' %}</li>
+        {% endif %}
+      {% endwith %}
+    </ul>
+  </div>
+</aside>
+{% endblock %}
+
+{% block messages %}
+  {% if messages %}
+    <div class="mx-4 mt-24 space-y-4 sm:ml-64 sm:px-8">
+      {% for message in messages %}
+        {% with tags=message.tags|default:"" %}
+          {% if 'error' in tags %}
+            {% with 'red' as alert_color %}
+              <div class="rounded-lg border border-{{ alert_color }}-200 bg-{{ alert_color }}-50 p-4 text-{{ alert_color }}-800 dark:border-{{ alert_color }}-900/50 dark:bg-{{ alert_color }}-900/30 dark:text-{{ alert_color }}-200">
+                {{ message|capfirst }}
+              </div>
+            {% endwith %}
+          {% elif 'success' in tags %}
+            {% with 'green' as alert_color %}
+              <div class="rounded-lg border border-{{ alert_color }}-200 bg-{{ alert_color }}-50 p-4 text-{{ alert_color }}-800 dark:border-{{ alert_color }}-900/50 dark:bg-{{ alert_color }}-900/30 dark:text-{{ alert_color }}-200">
+                {{ message|capfirst }}
+              </div>
+            {% endwith %}
+          {% elif 'warning' in tags %}
+            {% with 'yellow' as alert_color %}
+              <div class="rounded-lg border border-{{ alert_color }}-200 bg-{{ alert_color }}-50 p-4 text-{{ alert_color }}-800 dark:border-{{ alert_color }}-900/50 dark:bg-{{ alert_color }}-900/30 dark:text-{{ alert_color }}-200">
+                {{ message|capfirst }}
+              </div>
+            {% endwith %}
+          {% else %}
+            {% with 'blue' as alert_color %}
+              <div class="rounded-lg border border-{{ alert_color }}-200 bg-{{ alert_color }}-50 p-4 text-{{ alert_color }}-800 dark:border-{{ alert_color }}-900/50 dark:bg-{{ alert_color }}-900/30 dark:text-{{ alert_color }}-200">
+                {{ message|capfirst }}
+              </div>
+            {% endwith %}
+          {% endif %}
+        {% endwith %}
+      {% endfor %}
+    </div>
+  {% endif %}
+{% endblock %}
+
+{% block coltype %}colM mt-24 space-y-6 px-4 pb-12 sm:ml-64 sm:px-8{% endblock %}
+
+{% block footer %}
+  {{ block.super }}
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/flowbite/2.3.0/flowbite.min.js" integrity="sha512-uaP42gnikIze8ih/7gToYtL6vhfVqlhK/SXxPxq8np5xpoE2mR7BncpsbR9f7DmqDveoxu48UUfZo0fo0RKZxQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+  <script>
+    (function () {
+      const themeToggleBtn = document.getElementById('theme-toggle');
+      if (!themeToggleBtn) {
+        return;
+      }
+      const darkIcon = document.getElementById('theme-toggle-dark-icon');
+      const lightIcon = document.getElementById('theme-toggle-light-icon');
+      function setIcons(isDark) {
+        if (isDark) {
+          darkIcon.classList.add('hidden');
+          lightIcon.classList.remove('hidden');
+        } else {
+          lightIcon.classList.add('hidden');
+          darkIcon.classList.remove('hidden');
+        }
+      }
+      const storedTheme = localStorage.getItem('color-theme');
+      const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+      const isDark = storedTheme === 'dark' || (!storedTheme && prefersDark);
+      setIcons(isDark);
+      themeToggleBtn.addEventListener('click', function () {
+        const isCurrentlyDark = document.documentElement.classList.contains('dark');
+        if (isCurrentlyDark) {
+          document.documentElement.classList.remove('dark');
+          localStorage.setItem('color-theme', 'light');
+          setIcons(false);
+        } else {
+          document.documentElement.classList.add('dark');
+          localStorage.setItem('color-theme', 'dark');
+          setIcons(true);
+        }
+      });
+    })();
+  </script>
+{% endblock %}

--- a/flowbite_admin/templates/admin/change_form.html
+++ b/flowbite_admin/templates/admin/change_form.html
@@ -1,2 +1,125 @@
-<!-- change form -->
-{% block content %}<form method='post'>{% csrf_token %}{{ adminform }}</form>{% endblock %}
+{% extends "admin/base_site.html" %}
+{% load i18n admin_urls static admin_modify %}
+
+{% block title %}{% if errors %}{% translate "Error:" %} {% endif %}{{ block.super }}{% endblock %}
+
+{% block extrahead %}
+  {{ block.super }}
+  <script src="{% url 'admin:jsi18n' %}"></script>
+  {{ adminform.media }}
+  {{ media }}
+{% endblock %}
+
+{% block extrastyle %}
+  {{ block.super }}
+  <link rel="stylesheet" href="{% static 'admin/css/forms.css' %}">
+{% endblock %}
+
+{% block bodyclass %}{{ block.super }} app-{{ opts.app_label }} model-{{ opts.model_name }} change-form{% endblock %}
+
+{% if not is_popup %}
+  {% block breadcrumbs %}
+    <ol class="flex flex-wrap items-center gap-2 text-sm text-gray-500 dark:text-gray-400">
+      <li>
+        <a class="inline-flex items-center gap-1 rounded-lg px-3 py-1 font-medium text-gray-600 hover:bg-blue-50 hover:text-blue-700 dark:text-gray-300 dark:hover:bg-gray-800 dark:hover:text-white" href="{% url 'admin:index' %}">{% translate 'Home' %}</a>
+      </li>
+      <li aria-hidden="true" class="text-gray-400">/</li>
+      <li>
+        <a class="rounded-lg px-3 py-1 text-gray-600 hover:bg-blue-50 hover:text-blue-700 dark:text-gray-300 dark:hover:bg-gray-800 dark:hover:text-white" href="{% url 'admin:app_list' app_label=opts.app_label %}">{{ opts.app_config.verbose_name }}</a>
+      </li>
+      <li aria-hidden="true" class="text-gray-400">/</li>
+      <li>
+        {% if has_view_permission %}
+          <a class="rounded-lg px-3 py-1 text-gray-600 hover:bg-blue-50 hover:text-blue-700 dark:text-gray-300 dark:hover:bg-gray-800 dark:hover:text-white" href="{% url opts|admin_urlname:'changelist' %}">{{ opts.verbose_name_plural|capfirst }}</a>
+        {% else %}
+          <span class="rounded-lg px-3 py-1 text-gray-400 dark:text-gray-500">{{ opts.verbose_name_plural|capfirst }}</span>
+        {% endif %}
+      </li>
+      <li aria-hidden="true" class="text-gray-400">/</li>
+      <li class="rounded-lg bg-blue-50 px-3 py-1 font-semibold text-blue-700 dark:bg-blue-500/20 dark:text-blue-200">
+        {% if add %}
+          {% blocktranslate with name=opts.verbose_name %}Add {{ name }}{% endblocktranslate %}
+        {% else %}
+          {{ original|truncatewords:"18" }}
+        {% endif %}
+      </li>
+    </ol>
+  {% endblock %}
+{% endif %}
+
+{% block content %}
+  <div id="content-main" class="space-y-8">
+    {% block object-tools %}
+      {% if change and not is_popup %}
+        <ul class="object-tools flex flex-wrap items-center justify-end gap-2 text-sm font-medium">
+          {% block object-tools-items %}
+            {% change_form_object_tools %}
+          {% endblock %}
+        </ul>
+      {% endif %}
+    {% endblock %}
+
+    <form {% if has_file_field %}enctype="multipart/form-data" {% endif %}{% if form_url %}action="{{ form_url }}" {% endif %}method="post" id="{{ opts.model_name }}_form" novalidate class="space-y-6">
+      {% csrf_token %}
+      {% block form_top %}{% endblock %}
+
+      {% if is_popup %}<input type="hidden" name="{{ is_popup_var }}" value="1">{% endif %}
+      {% if to_field %}<input type="hidden" name="{{ to_field_var }}" value="{{ to_field }}">{% endif %}
+
+      {% if save_on_top %}
+        {% block submit_buttons_top %}
+          <div class="rounded-2xl bg-white p-4 shadow-sm ring-1 ring-gray-100 dark:bg-gray-800 dark:ring-gray-700">
+            {% submit_row %}
+          </div>
+        {% endblock %}
+      {% endif %}
+
+      {% if errors %}
+        <div class="rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-800 dark:border-red-900/50 dark:bg-red-900/30 dark:text-red-200">
+          <p>
+            {% blocktranslate count counter=errors|length %}Please correct the error below.{% plural %}Please correct the errors below.{% endblocktranslate %}
+          </p>
+          {{ adminform.form.non_field_errors }}
+        </div>
+      {% endif %}
+
+      {% block field_sets %}
+        {% for fieldset in adminform %}
+          <div class="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+            {% include "admin/includes/fieldset.html" with heading_level=2 prefix="fieldset" id_prefix=0 id_suffix=forloop.counter0 %}
+          </div>
+        {% endfor %}
+      {% endblock %}
+
+      {% block after_field_sets %}{% endblock %}
+
+      {% block inline_field_sets %}
+        {% for inline_admin_formset in inline_admin_formsets %}
+          <div class="rounded-2xl border border-dashed border-gray-300 bg-white p-6 shadow-sm dark:border-gray-600 dark:bg-gray-800">
+            {% include inline_admin_formset.opts.template %}
+          </div>
+        {% endfor %}
+      {% endblock %}
+
+      {% block after_related_objects %}{% endblock %}
+
+      {% block submit_buttons_bottom %}
+        <div class="rounded-2xl bg-white p-4 shadow-sm ring-1 ring-gray-100 dark:bg-gray-800 dark:ring-gray-700">
+          {% submit_row %}
+        </div>
+      {% endblock %}
+
+      {% block admin_change_form_document_ready %}
+        <script id="django-admin-form-add-constants"
+                src="{% static 'admin/js/change_form.js' %}"
+                {% if adminform and add %}
+                  data-model-name="{{ opts.model_name }}"
+                {% endif %}
+                async>
+        </script>
+      {% endblock %}
+
+      {% prepopulated_fields_js %}
+    </form>
+  </div>
+{% endblock %}

--- a/flowbite_admin/templates/admin/change_list.html
+++ b/flowbite_admin/templates/admin/change_list.html
@@ -1,2 +1,149 @@
-<!-- change list -->
-{% block content %}{% result_list cl %}{% endblock %}
+{% extends "admin/base_site.html" %}
+{% load i18n admin_urls static admin_list %}
+
+{% block title %}{% if cl.formset and cl.formset.errors %}{% translate "Error:" %} {% endif %}{{ block.super }}{% endblock %}
+
+{% block extrastyle %}
+  {{ block.super }}
+  <link rel="stylesheet" href="{% static 'admin/css/changelists.css' %}">
+  {% if cl.formset %}
+    <link rel="stylesheet" href="{% static 'admin/css/forms.css' %}">
+  {% endif %}
+  {% if cl.formset or action_form %}
+    <script src="{% url 'admin:jsi18n' %}"></script>
+  {% endif %}
+  {{ media.css }}
+  {% if not actions_on_top and not actions_on_bottom %}
+    <style>#changelist table thead th:first-child {width: inherit}</style>
+  {% endif %}
+{% endblock %}
+
+{% block extrahead %}
+  {{ block.super }}
+  {{ media.js }}
+  <script src="{% static 'admin/js/filters.js' %}" defer></script>
+{% endblock %}
+
+{% block bodyclass %}{{ block.super }} app-{{ opts.app_label }} model-{{ opts.model_name }} change-list{% endblock %}
+
+{% if not is_popup %}
+  {% block breadcrumbs %}
+    <ol class="flex flex-wrap items-center gap-2 text-sm text-gray-500 dark:text-gray-400">
+      <li>
+        <a class="inline-flex items-center gap-1 rounded-lg px-3 py-1 font-medium text-gray-600 hover:bg-blue-50 hover:text-blue-700 dark:text-gray-300 dark:hover:bg-gray-800 dark:hover:text-white" href="{% url 'admin:index' %}">{% translate 'Home' %}</a>
+      </li>
+      <li aria-hidden="true" class="text-gray-400">/</li>
+      <li>
+        <a class="rounded-lg px-3 py-1 text-gray-600 hover:bg-blue-50 hover:text-blue-700 dark:text-gray-300 dark:hover:bg-gray-800 dark:hover:text-white" href="{% url 'admin:app_list' app_label=cl.opts.app_label %}">{{ cl.opts.app_config.verbose_name }}</a>
+      </li>
+      <li aria-hidden="true" class="text-gray-400">/</li>
+      <li class="rounded-lg bg-blue-50 px-3 py-1 font-semibold text-blue-700 dark:bg-blue-500/20 dark:text-blue-200">{{ cl.opts.verbose_name_plural|capfirst }}</li>
+    </ol>
+  {% endblock %}
+{% endif %}
+
+{% block coltype %}{% endblock %}
+
+{% block content %}
+  <div id="content-main" class="space-y-6">
+    {% block object-tools %}
+      <ul class="object-tools flex flex-wrap items-center justify-end gap-2 text-sm font-medium">
+        {% block object-tools-items %}
+          {% change_list_object_tools %}
+        {% endblock %}
+      </ul>
+    {% endblock %}
+
+    {% if cl.formset and cl.formset.errors %}
+      <div class="rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-800 dark:border-red-900/50 dark:bg-red-900/30 dark:text-red-200">
+        <p>{% blocktranslate count counter=cl.formset.total_error_count %}Please correct the error below.{% plural %}Please correct the errors below.{% endblocktranslate %}</p>
+        {{ cl.formset.non_form_errors }}
+      </div>
+    {% endif %}
+
+    <div class="flex flex-col gap-6 lg:flex-row">
+      <div class="flex-1 space-y-6">
+        <div class="rounded-2xl border border-gray-200 bg-white p-4 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+          <div class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+            {% block search %}
+              <div class="md:w-1/2">{% search_form cl %}</div>
+            {% endblock %}
+            {% block date_hierarchy %}
+              {% if cl.date_hierarchy %}
+                <div class="text-sm text-gray-500 dark:text-gray-400">
+                  {% date_hierarchy cl %}
+                </div>
+              {% endif %}
+            {% endblock %}
+          </div>
+        </div>
+
+        <div class="rounded-2xl border border-gray-200 bg-white shadow-sm dark:border-gray-700 dark:bg-gray-800">
+          <div class="changelist-form-container overflow-hidden">
+            <form id="changelist-form" method="post"{% if cl.formset and cl.formset.is_multipart %} enctype="multipart/form-data"{% endif %} novalidate>
+              {% csrf_token %}
+              {% if cl.formset %}
+                <div class="hidden">{{ cl.formset.management_form }}</div>
+              {% endif %}
+
+              {% block result_list %}
+                <div class="space-y-4">
+                  {% if action_form and actions_on_top and cl.show_admin_actions %}
+                    <div class="rounded-lg border border-gray-200 bg-gray-50 p-4 dark:border-gray-700 dark:bg-gray-900/40">
+                      {% admin_actions %}
+                    </div>
+                  {% endif %}
+                  <div class="overflow-x-auto">
+                    {% result_list cl %}
+                  </div>
+                  {% if action_form and actions_on_bottom and cl.show_admin_actions %}
+                    <div class="rounded-lg border border-gray-200 bg-gray-50 p-4 dark:border-gray-700 dark:bg-gray-900/40">
+                      {% admin_actions %}
+                    </div>
+                  {% endif %}
+                </div>
+              {% endblock %}
+
+              {% block pagination %}
+                <div class="border-t border-gray-200 bg-white px-4 py-3 dark:border-gray-700 dark:bg-gray-800">
+                  {% pagination cl %}
+                </div>
+              {% endblock %}
+            </form>
+          </div>
+        </div>
+      </div>
+
+      {% block filters %}
+        {% if cl.has_filters %}
+          <div class="w-full shrink-0 space-y-4 lg:w-72">
+            <div class="rounded-2xl border border-gray-200 bg-white p-4 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+              <div class="flex items-center justify-between">
+                <h2 id="changelist-filter-header" class="text-sm font-semibold text-gray-700 dark:text-gray-200">{% translate 'Filter' %}</h2>
+                {% if cl.is_facets_optional or cl.has_active_filters %}
+                  <div class="text-xs text-gray-500 dark:text-gray-400">
+                    {% if cl.is_facets_optional %}
+                      <h3>
+                        {% if cl.add_facets %}<a class="hover:text-blue-600" href="{{ cl.remove_facet_link }}">{% translate "Hide counts" %}</a>{% else %}<a class="hover:text-blue-600" href="{{ cl.add_facet_link }}">{% translate "Show counts" %}</a>{% endif %}
+                      </h3>
+                    {% endif %}
+                    {% if cl.has_active_filters %}
+                      <h3><a class="hover:text-blue-600" href="{{ cl.clear_all_filters_qs }}">&#10006; {% translate "Clear all filters" %}</a></h3>
+                    {% endif %}
+                  </div>
+                {% endif %}
+              </div>
+              <div class="mt-4 space-y-4" id="changelist-filter" aria-labelledby="changelist-filter-header">
+                {% for spec in cl.filter_specs %}
+                  <div class="rounded-lg border border-gray-200 p-3 dark:border-gray-700">
+                    {% admin_list_filter cl spec %}
+                  </div>
+                {% endfor %}
+              </div>
+            </div>
+          </div>
+        {% endif %}
+      {% endblock %}
+    </div>
+  </div>
+{% endblock %}

--- a/flowbite_admin/templates/admin/delete_confirmation.html
+++ b/flowbite_admin/templates/admin/delete_confirmation.html
@@ -1,1 +1,63 @@
-<!-- delete confirmation -->
+{% extends "admin/base_site.html" %}
+{% load i18n admin_urls static %}
+
+{% block extrahead %}
+  {{ block.super }}
+  {{ media }}
+  <script src="{% static 'admin/js/cancel.js' %}" async></script>
+{% endblock %}
+
+{% block bodyclass %}{{ block.super }} app-{{ opts.app_label }} model-{{ opts.model_name }} delete-confirmation{% endblock %}
+
+{% block breadcrumbs %}
+  <ol class="flex flex-wrap items-center gap-2 text-sm text-gray-500 dark:text-gray-400">
+    <li><a class="inline-flex items-center gap-1 rounded-lg px-3 py-1 font-medium text-gray-600 hover:bg-blue-50 hover:text-blue-700 dark:text-gray-300 dark:hover:bg-gray-800 dark:hover:text-white" href="{% url 'admin:index' %}">{% translate 'Home' %}</a></li>
+    <li aria-hidden="true" class="text-gray-400">/</li>
+    <li><a class="rounded-lg px-3 py-1 text-gray-600 hover:bg-blue-50 hover:text-blue-700 dark:text-gray-300 dark:hover:bg-gray-800 dark:hover:text-white" href="{% url 'admin:app_list' app_label=opts.app_label %}">{{ opts.app_config.verbose_name }}</a></li>
+    <li aria-hidden="true" class="text-gray-400">/</li>
+    <li><a class="rounded-lg px-3 py-1 text-gray-600 hover:bg-blue-50 hover:text-blue-700 dark:text-gray-300 dark:hover:bg-gray-800 dark:hover:text-white" href="{% url opts|admin_urlname:'changelist' %}">{{ opts.verbose_name_plural|capfirst }}</a></li>
+    <li aria-hidden="true" class="text-gray-400">/</li>
+    <li><a class="rounded-lg px-3 py-1 text-gray-600 hover:bg-blue-50 hover:text-blue-700 dark:text-gray-300 dark:hover:bg-gray-800 dark:hover:text-white" href="{% url opts|admin_urlname:'change' object.pk|admin_urlquote %}">{{ object|truncatewords:"18" }}</a></li>
+    <li aria-hidden="true" class="text-gray-400">/</li>
+    <li class="rounded-lg bg-red-50 px-3 py-1 font-semibold text-red-700 dark:bg-red-900/30 dark:text-red-200">{% translate 'Delete' %}</li>
+  </ol>
+{% endblock %}
+
+{% block content %}
+  <div id="content-main">
+    <div class="space-y-6">
+      <div class="rounded-2xl border border-red-200 bg-red-50 p-6 text-sm text-red-800 shadow-sm dark:border-red-900/50 dark:bg-red-900/30 dark:text-red-200">
+        <h1 class="text-xl font-semibold">{% translate 'Delete confirmation' %}</h1>
+        {% if perms_lacking %}
+          {% block delete_forbidden %}
+            <p class="mt-4">{% blocktranslate with escaped_object=object %}Deleting the {{ object_name }} '{{ escaped_object }}' would result in deleting related objects, but your account doesn't have permission to delete the following types of objects:{% endblocktranslate %}</p>
+            <ul id="deleted-objects" class="mt-4 list-disc space-y-2 pl-6">{{ perms_lacking|unordered_list }}</ul>
+          {% endblock %}
+        {% elif protected %}
+          {% block delete_protected %}
+            <p class="mt-4">{% blocktranslate with escaped_object=object %}Deleting the {{ object_name }} '{{ escaped_object }}' would require deleting the following protected related objects:{% endblocktranslate %}</p>
+            <ul id="deleted-objects" class="mt-4 list-disc space-y-2 pl-6">{{ protected|unordered_list }}</ul>
+          {% endblock %}
+        {% else %}
+          {% block delete_confirm %}
+            <p class="mt-4">{% blocktranslate with escaped_object=object %}Are you sure you want to delete the {{ object_name }} "{{ escaped_object }}"? All of the following related items will be deleted:{% endblocktranslate %}</p>
+            <div class="mt-4 rounded-lg bg-white/70 p-4 text-sm text-gray-800 dark:bg-gray-900/70 dark:text-gray-200">
+              {% include "admin/includes/object_delete_summary.html" %}
+            </div>
+            <h2 class="mt-6 text-base font-semibold">{% translate "Objects" %}</h2>
+            <ul id="deleted-objects" class="mt-2 list-disc space-y-2 pl-6 text-sm">{{ deleted_objects|unordered_list }}</ul>
+            <form method="post" class="mt-6 space-y-4">{% csrf_token %}
+              <input type="hidden" name="post" value="yes">
+              {% if is_popup %}<input type="hidden" name="{{ is_popup_var }}" value="1">{% endif %}
+              {% if to_field %}<input type="hidden" name="{{ to_field_var }}" value="{{ to_field }}">{% endif %}
+              <div class="flex flex-col gap-3 sm:flex-row">
+                <button type="submit" class="inline-flex flex-1 items-center justify-center rounded-lg bg-red-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 dark:focus:ring-offset-red-900">{% translate 'Yes, I’m sure' %}</button>
+                <a href="#" class="inline-flex flex-1 items-center justify-center rounded-lg border border-gray-200 px-4 py-2 text-sm font-medium text-gray-700 transition hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-700 cancel-link">{% translate "No, take me back" %}</a>
+              </div>
+            </form>
+          {% endblock %}
+        {% endif %}
+      </div>
+    </div>
+  </div>
+{% endblock content %}

--- a/flowbite_admin/templates/admin/index.html
+++ b/flowbite_admin/templates/admin/index.html
@@ -1,1 +1,75 @@
-<!-- index page -->
+{% extends "admin/base_site.html" %}
+{% load i18n static log %}
+
+{% block extrastyle %}
+  {{ block.super }}
+  <link rel="stylesheet" href="{% static 'admin/css/dashboard.css' %}">
+{% endblock %}
+
+{% block coltype %}colMS mt-24 space-y-6 px-4 pb-12 sm:ml-64 sm:px-8{% endblock %}
+
+{% block bodyclass %}{{ block.super }} dashboard{% endblock %}
+
+{% block nav-breadcrumbs %}{% endblock %}
+
+{% block content %}
+  <div id="content-main" class="space-y-8">
+    <div class="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+      <div class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+        <div>
+          <h1 class="text-2xl font-semibold text-gray-900 dark:text-white">{% translate 'Welcome back' %}</h1>
+          <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">{% translate 'Choose an application to manage from the list below.' %}</p>
+        </div>
+        <div class="flex items-center gap-2">
+          <form method="post" action="{% url 'admin:logout' %}" class="inline">
+            {% csrf_token %}
+            <button type="submit" class="rounded-lg border border-gray-200 px-4 py-2 text-sm font-medium text-gray-700 transition hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-700">{% translate 'Log out' %}</button>
+          </form>
+          {% if site_url %}
+            <a href="{{ site_url }}" class="rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900">{% translate 'View site' %}</a>
+          {% endif %}
+        </div>
+      </div>
+    </div>
+
+    <div class="grid gap-6 lg:grid-cols-[2fr,1fr]">
+      <div class="space-y-6">
+        <div class="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+          {% include "admin/app_list.html" with app_list=app_list show_changelinks=True %}
+        </div>
+      </div>
+      <aside class="space-y-6">
+        <div class="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+          <h2 class="text-lg font-semibold text-gray-900 dark:text-white">{% translate 'Recent actions' %}</h2>
+          <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">{% translate 'My actions' %}</p>
+          {% get_admin_log 10 as admin_log for_user user %}
+          {% if not admin_log %}
+            <p class="mt-4 text-sm text-gray-500 dark:text-gray-400">{% translate 'None available' %}</p>
+          {% else %}
+            <ul class="mt-4 space-y-3">
+              {% for entry in admin_log %}
+                <li class="rounded-lg border border-gray-200 p-3 text-sm dark:border-gray-700 {% if entry.is_addition %}bg-green-50 text-green-800 dark:bg-green-900/30 dark:text-green-200{% elif entry.is_change %}bg-blue-50 text-blue-800 dark:bg-blue-900/30 dark:text-blue-200{% elif entry.is_deletion %}bg-red-50 text-red-800 dark:bg-red-900/30 dark:text-red-200{% else %}bg-gray-50 text-gray-700 dark:bg-gray-800 dark:text-gray-200{% endif %}">
+                  <span class="block text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                    {% if entry.is_addition %}{% translate 'Added' %}{% elif entry.is_change %}{% translate 'Changed' %}{% elif entry.is_deletion %}{% translate 'Deleted' %}{% endif %}
+                  </span>
+                  {% if entry.is_deletion or not entry.get_admin_url %}
+                    <span class="font-medium">{{ entry.object_repr }}</span>
+                  {% else %}
+                    <a class="font-medium hover:underline" href="{{ entry.get_admin_url }}">{{ entry.object_repr }}</a>
+                  {% endif %}
+                  <div class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                    {% if entry.content_type %}
+                      {% filter capfirst %}{{ entry.content_type.name }}{% endfilter %}
+                    {% else %}
+                      {% translate 'Unknown content' %}
+                    {% endif %}
+                  </div>
+                </li>
+              {% endfor %}
+            </ul>
+          {% endif %}
+        </div>
+      </aside>
+    </div>
+  </div>
+{% endblock %}

--- a/flowbite_admin/templates/admin/login.html
+++ b/flowbite_admin/templates/admin/login.html
@@ -1,1 +1,80 @@
-<!-- login page -->
+{% extends "admin/base_site.html" %}
+{% load i18n static %}
+
+{% block title %}{% if form.errors %}{% translate "Error:" %} {% endif %}{{ block.super }}{% endblock %}
+
+{% block extrastyle %}
+  {{ block.super }}
+  <link rel="stylesheet" href="{% static 'admin/css/login.css' %}">
+  {{ form.media }}
+{% endblock %}
+
+{% block bodyclass %}{{ block.super }} login bg-gray-50 dark:bg-gray-900{% endblock %}
+
+{% block usertools %}{% endblock %}
+{% block nav-global %}{% endblock %}
+{% block nav-sidebar %}{% endblock %}
+{% block nav-breadcrumbs %}{% endblock %}
+{% block content_title %}{% endblock %}
+{% block coltype %}colM mt-24 space-y-6 px-4 pb-12{% endblock %}
+
+{% block content %}
+  <div class="flex min-h-[70vh] items-center justify-center">
+    <div class="w-full max-w-md rounded-2xl border border-gray-200 bg-white p-8 shadow-xl dark:border-gray-700 dark:bg-gray-800">
+      <div class="mb-6 text-center">
+        <h1 class="text-2xl font-semibold text-gray-900 dark:text-white">{% translate 'Sign in to your account' %}</h1>
+        <p class="mt-2 text-sm text-gray-500 dark:text-gray-400">{% translate 'Enter your credentials to access the admin dashboard.' %}</p>
+      </div>
+
+      {% if form.errors and not form.non_field_errors %}
+        <div class="mb-4 rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-800 dark:border-red-900/50 dark:bg-red-900/30 dark:text-red-200">
+          {% blocktranslate count counter=form.errors.items|length %}Please correct the error below.{% plural %}Please correct the errors below.{% endblocktranslate %}
+        </div>
+      {% endif %}
+
+      {% if form.non_field_errors %}
+        <div class="mb-4 space-y-2">
+          {% for error in form.non_field_errors %}
+            <div class="rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-800 dark:border-red-900/50 dark:bg-red-900/30 dark:text-red-200">{{ error }}</div>
+          {% endfor %}
+        </div>
+      {% endif %}
+
+      {% if user.is_authenticated %}
+        <div class="mb-4 rounded-lg border border-yellow-200 bg-yellow-50 p-4 text-sm text-yellow-800 dark:border-yellow-900/50 dark:bg-yellow-900/30 dark:text-yellow-200">
+          {% blocktranslate trimmed %}
+            You are authenticated as {{ username }}, but are not authorized to
+            access this page. Would you like to login to a different account?
+          {% endblocktranslate %}
+        </div>
+      {% endif %}
+
+      <form action="{{ app_path }}" method="post" id="login-form" class="space-y-4">{% csrf_token %}
+        <div class="space-y-1">
+          {{ form.username.errors }}
+          <label for="{{ form.username.id_for_label }}" class="block text-sm font-medium text-gray-700 dark:text-gray-200">{{ form.username.label }}</label>
+          {{ form.username.as_widget(attrs={
+            'class': 'w-full rounded-lg border border-gray-300 bg-gray-50 p-3 text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white'
+          }) }}
+        </div>
+        <div class="space-y-1">
+          {{ form.password.errors }}
+          <label for="{{ form.password.id_for_label }}" class="block text-sm font-medium text-gray-700 dark:text-gray-200">{{ form.password.label }}</label>
+          {{ form.password.as_widget(attrs={
+            'class': 'w-full rounded-lg border border-gray-300 bg-gray-50 p-3 text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white'
+          }) }}
+          <input type="hidden" name="next" value="{{ next }}">
+        </div>
+        {% url 'admin_password_reset' as password_reset_url %}
+        {% if password_reset_url %}
+          <div class="text-right text-sm">
+            <a class="font-medium text-blue-600 hover:text-blue-500 dark:text-blue-400 dark:hover:text-blue-300" href="{{ password_reset_url }}">{% translate 'Forgotten your login credentials?' %}</a>
+          </div>
+        {% endif %}
+        <div>
+          <button type="submit" class="flex w-full items-center justify-center rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900">{% translate 'Log in' %}</button>
+        </div>
+      </form>
+    </div>
+  </div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- replace placeholder admin templates with Flowbite/Tailwind themed layouts and navigation
- render change forms, change lists, and delete confirmations with full Django admin features intact
- refresh login and dashboard experiences with accessible Flowbite components and dark-mode support

## Testing
- Not Run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dbbbaa471c8326bee8dcb58ce5c2d0