### PR TITLE
Add Django admin integration tests and CI workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,33 @@
+name: Django Tests
+
+on:
+  push:
+    branches: ["main", "master"]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install "django>=5.0,<6.0"
+          pip install -e .
+
+      - name: Run Django tests
+        env:
+          DJANGO_SETTINGS_MODULE: tests.settings
+        run: python -m django test

--- a/tests/admin.py
+++ b/tests/admin.py
@@ -1,0 +1,10 @@
+from django.contrib import admin
+
+from .models import Book
+
+
+@admin.register(Book)
+class BookAdmin(admin.ModelAdmin):
+    list_display = ("title", "author", "published")
+    search_fields = ("title", "author")
+    list_filter = ("published",)

--- a/tests/apps.py
+++ b/tests/apps.py
@@ -1,0 +1,8 @@
+from django.apps import AppConfig
+
+
+class AdminTestsConfig(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "tests"
+    label = "admin_tests"
+    verbose_name = "Flowbite Admin Test Models"

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,0 +1,14 @@
+from django.db import models
+
+
+class Book(models.Model):
+    title = models.CharField(max_length=200)
+    author = models.CharField(max_length=200, blank=True)
+    published = models.DateField(null=True, blank=True)
+
+    class Meta:
+        app_label = "admin_tests"
+        ordering = ("title",)
+
+    def __str__(self) -> str:  # pragma: no cover - trivial
+        return self.title

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,0 +1,70 @@
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parent
+
+SECRET_KEY = "test-secret-key"
+DEBUG = True
+ALLOWED_HOSTS: list[str] = ["testserver", "localhost", "127.0.0.1"]
+
+INSTALLED_APPS = [
+    "flowbite_admin",
+    "django.contrib.admin",
+    "django.contrib.auth",
+    "django.contrib.contenttypes",
+    "django.contrib.sessions",
+    "django.contrib.messages",
+    "django.contrib.staticfiles",
+    "tests.apps.AdminTestsConfig",
+]
+
+MIDDLEWARE = [
+    "django.middleware.security.SecurityMiddleware",
+    "django.contrib.sessions.middleware.SessionMiddleware",
+    "django.middleware.common.CommonMiddleware",
+    "django.middleware.csrf.CsrfViewMiddleware",
+    "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "django.contrib.messages.middleware.MessageMiddleware",
+    "django.middleware.clickjacking.XFrameOptionsMiddleware",
+]
+
+ROOT_URLCONF = "tests.urls"
+
+TEMPLATES = [
+    {
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": [],
+        "APP_DIRS": True,
+        "OPTIONS": {
+            "context_processors": [
+                "django.template.context_processors.debug",
+                "django.template.context_processors.request",
+                "django.contrib.auth.context_processors.auth",
+                "django.contrib.messages.context_processors.messages",
+            ],
+        },
+    }
+]
+
+WSGI_APPLICATION = "tests.wsgi.application"
+
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": ":memory:",
+    }
+}
+
+AUTH_PASSWORD_VALIDATORS: list[dict[str, str]] = []
+
+LANGUAGE_CODE = "en-us"
+TIME_ZONE = "UTC"
+USE_I18N = True
+USE_TZ = True
+
+STATIC_URL = "/static/"
+
+DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
+
+PASSWORD_HASHERS = ["django.contrib.auth.hashers.MD5PasswordHasher"]
+
+MIGRATION_MODULES = {"admin_tests": None}

--- a/tests/test_admin_flowbite.py
+++ b/tests/test_admin_flowbite.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from django.contrib.auth import get_user_model
+from django.test import Client, TestCase
+from django.urls import reverse
+
+from .models import Book
+
+
+class AdminFlowbiteTests(TestCase):
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.username = "admin"
+        cls.password = "password123"
+        cls.user = get_user_model().objects.create_superuser(
+            username=cls.username,
+            email="admin@example.com",
+            password=cls.password,
+        )
+        cls.book = Book.objects.create(title="The Flowbite Book", author="Tester")
+
+    def setUp(self) -> None:
+        self.client: Client = Client()
+
+    def login(self) -> None:
+        logged_in = self.client.login(username=self.username, password=self.password)
+        self.assertTrue(logged_in, "Failed to authenticate test client")
+
+    def test_login_page_renders_flowbite_styles(self) -> None:
+        response = self.client.get(reverse("admin:login"))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "flowbite-admin.css")
+        self.assertContains(response, "Sign in to your account")
+
+    def test_admin_index_displays_sidebar_navigation(self) -> None:
+        self.login()
+        response = self.client.get(reverse("admin:index"))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "flowbite-admin.css")
+        self.assertContains(response, "data-drawer-target=\"logo-sidebar\"")
+        self.assertContains(response, "id=\"logo-sidebar\"")
+
+    def test_change_list_uses_flowbite_layout(self) -> None:
+        self.login()
+        response = self.client.get(reverse("admin:admin_tests_book_changelist"))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "rounded-2xl border border-gray-200")
+        self.assertContains(response, "flowbite-admin.css")
+
+    def test_change_form_has_flowbite_form_controls(self) -> None:
+        self.login()
+        url = reverse("admin:admin_tests_book_change", args=[self.book.pk])
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "rounded-2xl border border-gray-200 bg-white")
+        self.assertContains(response, "bg-white p-4 shadow-sm ring-1 ring-gray-100")
+
+    def test_delete_confirmation_template_renders(self) -> None:
+        self.login()
+        url = reverse("admin:admin_tests_book_delete", args=[self.book.pk])
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Delete confirmation")
+        self.assertContains(response, "Yes, I’m sure")
+
+    def test_change_form_submission_roundtrip(self) -> None:
+        self.login()
+        url = reverse("admin:admin_tests_book_change", args=[self.book.pk])
+        response = self.client.post(
+            url,
+            {
+                "title": "Updated Flowbite Book",
+                "author": "Tester",
+                "published": "2024-01-01",
+                "_save": "Save",
+            },
+            follow=True,
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "was changed successfully")
+
+    def test_change_list_delete_action_confirmation(self) -> None:
+        self.login()
+        response = self.client.post(
+            reverse("admin:admin_tests_book_changelist"),
+            {
+                "action": "delete_selected",
+                "select_across": 0,
+                "index": 0,
+                "_selected_action": [self.book.pk],
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Are you sure you want to delete")
+        self.assertContains(response, "Yes, I’m sure")

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,0 +1,6 @@
+from django.contrib import admin
+from django.urls import path
+
+urlpatterns = [
+    path("admin/", admin.site.urls),
+]

--- a/tests/wsgi.py
+++ b/tests/wsgi.py
@@ -1,0 +1,7 @@
+import os
+
+from django.core.wsgi import get_wsgi_application
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "tests.settings")
+
+application = get_wsgi_application()


### PR DESCRIPTION
## Summary
- add a minimal Django settings module and sample model for exercising the Flowbite admin templates
- cover the admin login, index, change list, change form, and delete confirmation views with integration tests that assert Flowbite-specific UI elements
- configure GitHub Actions to install Django 5.x and run the Django test suite automatically

## Testing
- DJANGO_SETTINGS_MODULE=tests.settings python -m django test

------
https://chatgpt.com/codex/tasks/task_e_68dbc2a28afc8326b81eb44e2d928a96