### PR TITLE
Improve Flowbite admin CSS generation

### DIFF
--- a/flowbite_admin/static/flowbite_admin/css/flowbite-admin.css
+++ b/flowbite_admin/static/flowbite_admin/css/flowbite-admin.css
@@ -1,3 +1,63 @@
+/* Flowbite Admin base styles */
+*, ::before, ::after {
+  box-sizing: border-box;
+  border-width: 0;
+  border-style: solid;
+  border-color: #e5e7eb;
+}
+::before, ::after {
+  --tw-content: '';
+}
+html {
+  line-height: 1.5;
+  -webkit-text-size-adjust: 100%;
+  font-family: 'Inter', ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+body {
+  margin: 0;
+  line-height: inherit;
+  background-color: #f9fafb;
+  color: #1f2937;
+}
+h1, h2, h3, h4, h5, h6 {
+  font-size: inherit;
+  font-weight: inherit;
+}
+a {
+  color: inherit;
+  text-decoration: inherit;
+}
+button, input, optgroup, select, textarea {
+  font-family: inherit;
+  font-size: 100%;
+  line-height: inherit;
+  color: inherit;
+  margin: 0;
+}
+button, select {
+  text-transform: none;
+}
+button, [type='button'], [type='reset'], [type='submit'] {
+  -webkit-appearance: button;
+  background-color: transparent;
+  background-image: none;
+}
+table {
+  border-collapse: collapse;
+}
+th {
+  font-weight: 600;
+  text-align: inherit;
+}
+img, svg, video, canvas, audio, iframe, embed, object {
+  display: block;
+  vertical-align: middle;
+}
+img, video {
+  max-width: 100%;
+  height: auto;
+}
+
 /* Generated utility classes */
 :root { --fb-focus-ring-width: 2px; --fb-focus-ring-offset: 0; --fb-focus-ring-color: rgba(59, 130, 246, 0.45); --fb-focus-ring-offset-color: transparent; }
 .dark :focus { box-shadow: 0 0 0 var(--fb-focus-ring-width, 2px) var(--fb-focus-ring-color, rgba(59, 130, 246, 0.45)); }
@@ -45,7 +105,7 @@
 .dark .dark\:hover\:bg-gray-800:hover { background-color: #1f2937; }
 .dark .dark\:hover\:text-blue-300:hover { color: #93c5fd; }
 .dark .dark\:hover\:text-white:hover { color: #ffffff; }
-.dark .dark\:ring-gray-700 { box-shadow: 0 0 0 1px #374151; }
+.dark .dark\:ring-gray-700 { box-shadow: 0 0 0 1px #374151; --fb-focus-ring-color: rgba(55, 65, 81, 0.45); }
 .dark .dark\:text-blue-200 { color: #bfdbfe; }
 .dark .dark\:text-blue-400 { color: #60a5fa; }
 .dark .dark\:text-gray-100 { color: #f1f5f9; }
@@ -144,7 +204,7 @@
 .py-3 { padding-top: 0.75rem; padding-bottom: 0.75rem; }
 .py-4 { padding-top: 1rem; padding-bottom: 1rem; }
 .ring-1 { box-shadow: 0 0 0 1px rgba(148, 163, 184, 0.4); }
-.ring-gray-100 { box-shadow: 0 0 0 1px #f1f5f9; }
+.ring-gray-100 { box-shadow: 0 0 0 1px #f1f5f9; --fb-focus-ring-color: rgba(241, 245, 249, 0.45); }
 .rounded-2xl { border-radius: 1rem; }
 .rounded-lg { border-radius: 0.5rem; }
 .shadow-sm { box-shadow: 0 1px 2px rgba(15, 23, 42, 0.05); }


### PR DESCRIPTION
## Summary
- add Flowbite/Tailwind-style base styles to the bundled stylesheet so the admin layout inherits the expected typography, resets, and utility coverage
- expand the custom CSS builder to ignore template artifacts, generate the additional utilities (including responsive and focus-ring variants), and prepend the shared base styles before emitting the utilities

## Testing
- python -m django test --settings=tests.settings

------
https://chatgpt.com/codex/tasks/task_e_68dbb25ae1448326b1d2783808de1095