### PR TITLE
Enhance admin top bar layout

### DIFF
--- a/flowbite_admin/static/flowbite_admin/css/flowbite-admin.css
+++ b/flowbite_admin/static/flowbite_admin/css/flowbite-admin.css
@@ -189,6 +189,44 @@ img, video {
 .overflow-hidden { overflow: hidden; }
 .overflow-x-auto { overflow-x: auto; }
 .overflow-y-auto { overflow-y: auto; }
+.sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0; }
+.with-sidebar-offset { padding-left: 0; }
+@media (min-width: 640px) { .with-sidebar-offset { padding-left: 16rem; } }
+.topbar-search { display: none; position: relative; align-items: center; width: 100%; max-width: 20rem; }
+@media (min-width: 640px) { .topbar-search { display: flex; } }
+.topbar-search__icon { position: absolute; left: 0.9rem; top: 50%; transform: translateY(-50%); width: 1.1rem; height: 1.1rem; color: #6b7280; }
+.topbar-search__input { width: 100%; padding: 0.5rem 0.75rem 0.5rem 2.5rem; border-radius: 9999px; border: 1px solid #d1d5db; background-color: #f8fafc; color: #111827; font-size: 0.875rem; transition: border-color 150ms ease, box-shadow 150ms ease; }
+.topbar-search__input::placeholder { color: #6b7280; }
+.topbar-search__input:focus { outline: none; border-color: #2563eb; box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.2); background-color: #ffffff; }
+.dark .topbar-search__icon { color: #9ca3af; }
+.dark .topbar-search__input { background-color: #1f2937; border-color: #374151; color: #f3f4f6; }
+.dark .topbar-search__input::placeholder { color: #9ca3af; }
+.dark .topbar-search__input:focus { border-color: #60a5fa; box-shadow: 0 0 0 3px rgba(96, 165, 250, 0.25); background-color: #111827; }
+.topbar-icon-group { display: flex; align-items: center; gap: 0.5rem; }
+.topbar-icon-button { display: inline-flex; align-items: center; justify-content: center; width: 2.5rem; height: 2.5rem; border-radius: 0.75rem; border: 1px solid #e5e7eb; background-color: #ffffff; color: #374151; transition: background-color 150ms ease, color 150ms ease, border-color 150ms ease, box-shadow 150ms ease; }
+.topbar-icon-button:hover { background-color: #eff6ff; color: #1d4ed8; border-color: #bfdbfe; }
+.topbar-icon-button:focus { outline: none; border-color: #2563eb; box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.2); }
+.topbar-icon-button svg { pointer-events: none; }
+.dark .topbar-icon-button { border-color: #374151; background-color: #111827; color: #e5e7eb; }
+.dark .topbar-icon-button:hover { background-color: #1f2937; color: #93c5fd; border-color: #4b5563; }
+.dark .topbar-icon-button:focus { border-color: #60a5fa; box-shadow: 0 0 0 3px rgba(96, 165, 250, 0.25); }
+.topbar-user { display: none; align-items: center; gap: 0.75rem; }
+@media (min-width: 768px) { .topbar-user { display: flex; } }
+.topbar-user__text { display: flex; flex-direction: column; gap: 0.25rem; text-align: right; }
+.topbar-user__greeting { margin: 0; font-size: 0.875rem; font-weight: 600; color: #1f2937; }
+.topbar-user__links { display: flex; flex-wrap: wrap; justify-content: flex-end; gap: 0.35rem; font-size: 0.75rem; color: #4b5563; }
+.topbar-user__link { font-weight: 500; color: #2563eb; text-decoration: none; }
+.topbar-user__link:hover { color: #1d4ed8; }
+.topbar-user__link:focus { outline: none; text-decoration: underline; }
+.topbar-user__logout { background: none; border: none; padding: 0; cursor: pointer; }
+.topbar-user__divider { color: #9ca3af; }
+.topbar-avatar { display: inline-flex; align-items: center; justify-content: center; width: 2.25rem; height: 2.25rem; border-radius: 9999px; background: linear-gradient(135deg, #2563eb, #1d4ed8); color: #ffffff; font-weight: 600; font-size: 0.95rem; text-transform: uppercase; box-shadow: 0 4px 10px rgba(37, 99, 235, 0.25); }
+.dark .topbar-user__greeting { color: #f3f4f6; }
+.dark .topbar-user__links { color: #9ca3af; }
+.dark .topbar-user__link { color: #93c5fd; }
+.dark .topbar-user__link:hover { color: #bfdbfe; }
+.dark .topbar-user__divider { color: #6b7280; }
+.dark .topbar-avatar { background: linear-gradient(135deg, #60a5fa, #2563eb); box-shadow: 0 4px 10px rgba(37, 99, 235, 0.35); }
 .p-2 { padding: 0.5rem; }
 .p-3 { padding: 0.75rem; }
 .p-4 { padding: 1rem; }

--- a/flowbite_admin/templates/admin/base_site.html
+++ b/flowbite_admin/templates/admin/base_site.html
@@ -32,7 +32,7 @@
 {% block bodyclass %}{{ block.super }} bg-gray-50 dark:bg-gray-900{% endblock %}
 
 {% block header %}
-<header class="fixed inset-x-0 top-0 z-30 border-b border-gray-200 bg-white/95 backdrop-blur dark:border-gray-700 dark:bg-gray-900/95">
+<header class="fixed inset-x-0 top-0 z-30 border-b border-gray-200 bg-white/95 backdrop-blur dark:border-gray-700 dark:bg-gray-900/95 with-sidebar-offset">
   <div class="mx-auto flex max-w-full items-center justify-between px-4 py-3 sm:px-6 lg:px-8">
     <div class="flex items-center gap-3">
       <button type="button" class="inline-flex items-center rounded-lg border border-gray-200 p-2 text-sm text-gray-500 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-800" data-drawer-target="logo-sidebar" data-drawer-toggle="logo-sidebar" aria-controls="logo-sidebar" aria-label="{% translate 'Toggle navigation' %}">
@@ -45,8 +45,27 @@
         <span class="hidden md:inline">{% firstof site_title site_header _('Flowbite Admin') %}</span>
       </a>
     </div>
-    <div class="flex items-center gap-2">
-      <button id="theme-toggle" type="button" class="inline-flex items-center rounded-lg border border-gray-200 p-2 text-sm text-gray-500 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-800" aria-label="{% translate 'Toggle dark mode' %}">
+    <div class="flex flex-1 items-center justify-end gap-3">
+      <form role="search" class="topbar-search" action="{% url 'admin:index' %}" method="get">
+        <label class="sr-only" for="topbar-search">{% translate 'Search' %}</label>
+        <svg class="topbar-search__icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M21 21l-4.35-4.35m0 0A7.5 7.5 0 1010.5 18a7.5 7.5 0 006.15-3.35z" />
+        </svg>
+        <input type="search" id="topbar-search" name="q" placeholder="{% translate 'Search' %}" class="topbar-search__input" />
+      </form>
+      <div class="topbar-icon-group">
+        <button type="button" class="topbar-icon-button" aria-label="{% translate 'Show notifications' %}">
+          <svg class="h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6 6 0 10-12 0v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9" />
+          </svg>
+        </button>
+        <button type="button" class="topbar-icon-button" aria-label="{% translate 'Open quick actions' %}">
+          <svg class="h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4 6h4M6 4v4m10-2h4m-2-2v4M4 18h4m-2-2v4m10-2h4m-2-2v4" />
+          </svg>
+        </button>
+      </div>
+      <button id="theme-toggle" type="button" class="topbar-icon-button" aria-label="{% translate 'Toggle dark mode' %}">
         <svg id="theme-toggle-dark-icon" class="hidden h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
           <path d="M17.293 13.293a8 8 0 11-10.586-10.586 8.001 8.001 0 1010.586 10.586z" />
         </svg>
@@ -55,31 +74,34 @@
         </svg>
       </button>
       {% if has_permission %}
-      <div class="hidden text-right text-sm sm:block">
-        <p class="font-medium text-gray-900 dark:text-gray-100">{% block welcome-msg %}{% translate 'Welcome,' %} <strong>{% firstof user.get_short_name user.get_username %}</strong>{% endblock %}</p>
-        <div class="mt-1 space-x-2 text-xs text-gray-500 dark:text-gray-400">
-          {% block userlinks %}
-            {% if site_url %}
-              <a class="hover:text-blue-600" href="{{ site_url }}">{% translate 'View site' %}</a>
-            {% endif %}
-            {% if user.is_active and user.is_staff %}
-              {% url 'django-admindocs-docroot' as docsroot %}
-              {% if docsroot %}
-                <span aria-hidden="true">·</span>
-                <a class="hover:text-blue-600" href="{{ docsroot }}">{% translate 'Documentation' %}</a>
+      <div class="topbar-user">
+        <div class="topbar-user__text">
+          <p class="topbar-user__greeting">{% block welcome-msg %}{% translate 'Welcome,' %} <strong>{% firstof user.get_short_name user.get_username %}</strong>{% endblock %}</p>
+          <div class="topbar-user__links">
+            {% block userlinks %}
+              {% if site_url %}
+                <a class="topbar-user__link" href="{{ site_url }}">{% translate 'View site' %}</a>
               {% endif %}
-            {% endif %}
-            {% if user.has_usable_password %}
-              <span aria-hidden="true">·</span>
-              <a class="hover:text-blue-600" href="{% url 'admin:password_change' %}">{% translate 'Change password' %}</a>
-            {% endif %}
-            <span aria-hidden="true">·</span>
-            <form id="logout-form" method="post" action="{% url 'admin:logout' %}" class="inline">
-              {% csrf_token %}
-              <button type="submit" class="font-medium text-blue-600 hover:text-blue-500 focus:outline-none dark:text-blue-400">{% translate 'Log out' %}</button>
-            </form>
-          {% endblock %}
+              {% if user.is_active and user.is_staff %}
+                {% url 'django-admindocs-docroot' as docsroot %}
+                {% if docsroot %}
+                  <span class="topbar-user__divider" aria-hidden="true">·</span>
+                  <a class="topbar-user__link" href="{{ docsroot }}">{% translate 'Documentation' %}</a>
+                {% endif %}
+              {% endif %}
+              {% if user.has_usable_password %}
+                <span class="topbar-user__divider" aria-hidden="true">·</span>
+                <a class="topbar-user__link" href="{% url 'admin:password_change' %}">{% translate 'Change password' %}</a>
+              {% endif %}
+              <span class="topbar-user__divider" aria-hidden="true">·</span>
+              <form id="logout-form" method="post" action="{% url 'admin:logout' %}" class="inline">
+                {% csrf_token %}
+                <button type="submit" class="topbar-user__link topbar-user__logout">{% translate 'Log out' %}</button>
+              </form>
+            {% endblock %}
+          </div>
         </div>
+        <span class="topbar-avatar" aria-hidden="true">{{ user.get_short_name|default:user.get_username|slice:":1"|upper }}</span>
       </div>
       {% endif %}
     </div>


### PR DESCRIPTION
## Summary
- add a global header search form and quick action buttons to the admin top bar
- restyle the authenticated user menu with avatar treatment and improved contrast
- extend the CSS bundle with utilities for the refreshed top bar and sidebar offset

## Testing
- python -m django test --settings=tests.settings

------
https://chatgpt.com/codex/tasks/task_e_68dc089af1f083268f717ab5af195b1d