### PR TITLE
Refine admin sidebar styling

### DIFF
--- a/flowbite_admin/static/flowbite_admin/css/flowbite-admin.css
+++ b/flowbite_admin/static/flowbite_admin/css/flowbite-admin.css
@@ -63,6 +63,7 @@ img, video {
 .dark :focus { box-shadow: 0 0 0 var(--fb-focus-ring-width, 2px) var(--fb-focus-ring-color, rgba(59, 130, 246, 0.45)); }
 .backdrop-blur { backdrop-filter: blur(8px); }
 .bg-blue-50 { background-color: #eff6ff; }
+.bg-blue-100 { background-color: #dbeafe; }
 .bg-blue-600 { background-color: #2563eb; }
 .bg-gray-50 { background-color: #f9fafb; }
 .bg-green-50 { background-color: #ecfdf5; }
@@ -120,6 +121,7 @@ img, video {
 .fixed { position: fixed; }
 .flex { display: flex; }
 .flex-1 { flex: 1 1 0%; }
+.flex-shrink-0 { flex-shrink: 0; }
 .flex-col { flex-direction: column; }
 .flex-wrap { flex-wrap: wrap; }
 .focus\:outline-none:focus { outline: none; }
@@ -140,9 +142,16 @@ img, video {
 .gap-4 { gap: 1rem; }
 .gap-6 { gap: 1.5rem; }
 .grid { display: grid; }
+.group { position: relative; }
+.group:hover .group-hover\:bg-blue-100 { background-color: #dbeafe; }
+.group:hover .group-hover\:text-blue-600 { color: #2563eb; }
+.dark .group:hover .dark\:group-hover\:bg-blue-900\/30 { background-color: rgba(30, 58, 138, 0.3); }
+.dark .group:hover .dark\:group-hover\:bg-blue-900\/40 { background-color: rgba(30, 58, 138, 0.4); }
+.dark .group:hover .dark\:group-hover\:text-blue-300 { color: #93c5fd; }
 .h-10 { height: 2.5rem; }
 .h-4 { height: 1rem; }
 .h-5 { height: 1.25rem; }
+.h-8 { height: 2rem; }
 .h-full { height: 100%; }
 .h-screen { height: 100vh; }
 .hidden { display: none; }
@@ -187,6 +196,7 @@ img, video {
 .mx-auto { margin-left: auto; margin-right: auto; }
 .object-tools { display: flex; gap: 0.5rem; }
 .overflow-hidden { overflow: hidden; }
+.truncate { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .overflow-x-auto { overflow-x: auto; }
 .overflow-y-auto { overflow-y: auto; }
 .sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0; }
@@ -238,12 +248,14 @@ img, video {
 .px-3 { padding-left: 0.75rem; padding-right: 0.75rem; }
 .px-4 { padding-left: 1rem; padding-right: 1rem; }
 .py-1 { padding-top: 0.25rem; padding-bottom: 0.25rem; }
+.py-0\.5 { padding-top: 0.125rem; padding-bottom: 0.125rem; }
 .py-2 { padding-top: 0.5rem; padding-bottom: 0.5rem; }
 .py-3 { padding-top: 0.75rem; padding-bottom: 0.75rem; }
 .py-4 { padding-top: 1rem; padding-bottom: 1rem; }
 .ring-1 { box-shadow: 0 0 0 1px rgba(148, 163, 184, 0.4); }
 .ring-gray-100 { box-shadow: 0 0 0 1px #f1f5f9; --fb-focus-ring-color: rgba(241, 245, 249, 0.45); }
 .rounded-2xl { border-radius: 1rem; }
+.rounded-xl { border-radius: 0.75rem; }
 .rounded-lg { border-radius: 0.5rem; }
 .shadow-sm { box-shadow: 0 1px 2px rgba(15, 23, 42, 0.05); }
 .shadow-xl { box-shadow: 0 20px 25px -5px rgba(15, 23, 42, 0.1), 0 10px 10px -5px rgba(15, 23, 42, 0.04); }
@@ -282,16 +294,24 @@ img, video {
 .text-white { color: #ffffff; }
 .text-xl { font-size: 1.25rem; line-height: 1.75rem; }
 .text-xs { font-size: 0.75rem; line-height: 1rem; }
+.text-\[0\.7rem\] { font-size: 0.7rem; line-height: 1rem; }
+.text-\[0\.65rem\] { font-size: 0.65rem; line-height: 0.95rem; }
 .text-yellow-800 { color: #92400e; }
 .top-0 { top: 0; }
 .tracking-wide { letter-spacing: 0.05em; }
 .tracking-widest { letter-spacing: 0.1em; }
+.tracking-\[0\.35em\] { letter-spacing: 0.35em; }
+.tracking-\[0\.3em\] { letter-spacing: 0.3em; }
+.tracking-\[0\.25em\] { letter-spacing: 0.25em; }
 .transition { transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1); }
+.transition-colors { transition-property: color, background-color, border-color, text-decoration-color, fill, stroke; transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1); transition-duration: 150ms; }
+.duration-150 { transition-duration: 150ms; }
 .transition-transform { transition-property: transform; transition-duration: 0.2s; transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1); }
 .uppercase { text-transform: uppercase; }
 .w-10 { width: 2.5rem; }
 .w-4 { width: 1rem; }
 .w-5 { width: 1.25rem; }
+.w-8 { width: 2rem; }
 .w-64 { width: 16rem; }
 .w-full { width: 100%; }
 .z-30 { z-index: 30; }

--- a/flowbite_admin/templates/admin/base_site.html
+++ b/flowbite_admin/templates/admin/base_site.html
@@ -134,26 +134,50 @@
 <aside id="logo-sidebar" class="fixed left-0 top-0 z-40 h-screen w-64 -translate-x-full border-r border-gray-200 bg-white pt-20 transition-transform dark:border-gray-700 dark:bg-gray-900 sm:translate-x-0" aria-label="{% translate 'Sidebar' %}">
   <div class="h-full overflow-y-auto px-4 pb-6">
     <div class="mb-6 hidden sm:block">
-      <p class="text-xs font-semibold uppercase tracking-widest text-gray-400 dark:text-gray-500">{% translate 'Navigation' %}</p>
+      <p class="px-3 text-[0.65rem] font-semibold uppercase tracking-[0.35em] text-gray-400 dark:text-gray-500">{% translate 'Navigation' %}</p>
     </div>
-    <ul class="space-y-1 text-sm font-medium">
+    <ul class="space-y-6 text-sm font-medium">
       {% with apps=app_list|default:available_apps %}
         {% if apps %}
           {% for app in apps %}
             <li>
-              <div class="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">{{ app.name }}</div>
-              <ul class="mt-2 space-y-1">
+              <div class="flex items-center gap-3 px-3 text-[0.7rem] font-semibold uppercase tracking-[0.3em] text-gray-400 dark:text-gray-500">
+                <span class="inline-flex h-8 w-8 items-center justify-center rounded-xl bg-gray-100 text-gray-500 dark:bg-gray-800 dark:text-gray-400">
+                  <svg class="h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 5.25h16.5M3.75 9.75h16.5m-16.5 4.5h16.5m-16.5 4.5h16.5" />
+                  </svg>
+                </span>
+                <span class="text-xs tracking-[0.25em] text-gray-500 dark:text-gray-400">{{ app.name }}</span>
+              </div>
+              <ul class="mt-3 space-y-1">
                 {% for model in app.models %}
                   <li>
                     {% if model.admin_url %}
-                      <a href="{{ model.admin_url }}" class="flex items-center justify-between rounded-lg px-3 py-2 text-gray-600 transition hover:bg-blue-50 hover:text-blue-700 dark:text-gray-300 dark:hover:bg-gray-800 dark:hover:text-white">
-                        <span>{{ model.name }}</span>
+                      <a href="{{ model.admin_url }}" class="group flex items-center gap-3 rounded-xl px-3 py-2 text-gray-600 transition-colors duration-150 hover:bg-gray-100 hover:text-gray-900 dark:text-gray-300 dark:hover:bg-gray-800 dark:hover:text-white">
+                        <span class="inline-flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg bg-gray-100 text-gray-500 transition-colors duration-150 group-hover:bg-blue-100 group-hover:text-blue-600 dark:bg-gray-800 dark:text-gray-400 dark:group-hover:bg-blue-900/30 dark:group-hover:text-blue-300">
+                          <svg class="h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 6.75h15M4.5 12h15m-15 5.25h15" />
+                          </svg>
+                        </span>
+                        <span class="flex-1 truncate text-sm font-medium">{{ model.name }}</span>
                         {% if model.add_url %}
-                          <span class="text-xs font-semibold text-blue-600 dark:text-blue-400" title="{% translate 'Add' %}">+</span>
+                          <span class="inline-flex items-center rounded-lg bg-blue-50 px-2 py-0.5 text-[0.65rem] font-semibold uppercase tracking-wide text-blue-600 transition-colors duration-150 group-hover:bg-blue-100 dark:bg-blue-900/30 dark:text-blue-300 dark:group-hover:bg-blue-900/40" title="{% translate 'Add' %}">
+                            <svg class="h-3 w-3" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" aria-hidden="true">
+                              <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
+                            </svg>
+                            <span class="sr-only">{% translate 'Add' %}</span>
+                          </span>
                         {% endif %}
                       </a>
                     {% else %}
-                      <span class="flex items-center rounded-lg px-3 py-2 text-gray-400 dark:text-gray-500">{{ model.name }}</span>
+                      <span class="flex items-center gap-3 rounded-xl px-3 py-2 text-gray-400 dark:text-gray-500">
+                        <span class="inline-flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg bg-gray-100 text-gray-400 dark:bg-gray-800 dark:text-gray-600">
+                          <svg class="h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 6.75h15M4.5 12h15m-15 5.25h15" />
+                          </svg>
+                        </span>
+                        <span class="flex-1 truncate text-sm font-medium">{{ model.name }}</span>
+                      </span>
                     {% endif %}
                   </li>
                 {% endfor %}


### PR DESCRIPTION
## Summary
- restyle the admin sidebar markup with iconography, typography adjustments, and hover treatments to mirror the provided reference
- extend the bundled CSS utilities to support the updated spacing, tracking, transition, and badge styles used by the sidebar

## Testing
- pytest *(fails: settings module is not configured in the default environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc0bd349848326b0c57ce5dd9e15ec