### PR TITLE
Add list-none utility to Flowbite Admin CSS

### DIFF
--- a/flowbite_admin/static/flowbite_admin/css/flowbite-admin.css
+++ b/flowbite_admin/static/flowbite_admin/css/flowbite-admin.css
@@ -63,13 +63,16 @@ img, video {
 .dark :focus { box-shadow: 0 0 0 var(--fb-focus-ring-width, 2px) var(--fb-focus-ring-color, rgba(59, 130, 246, 0.45)); }
 .backdrop-blur { backdrop-filter: blur(8px); }
 .bg-blue-50 { background-color: #eff6ff; }
-.bg-blue-100 { background-color: #dbeafe; }
 .bg-blue-600 { background-color: #2563eb; }
+.bg-gray-100 { background-color: #f1f5f9; }
 .bg-gray-50 { background-color: #f9fafb; }
+.bg-gray-50\/60 { background-color: rgba(249, 250, 251, 0.6); }
+.bg-gray-900\/60 { background-color: rgba(17, 24, 39, 0.6); }
 .bg-green-50 { background-color: #ecfdf5; }
 .bg-red-50 { background-color: #fef2f2; }
 .bg-red-600 { background-color: #dc2626; }
 .bg-white { background-color: #ffffff; }
+.bg-white\/0 { background-color: rgba(255, 255, 255, 0); }
 .bg-white\/70 { background-color: rgba(255, 255, 255, 0.7); }
 .bg-white\/95 { background-color: rgba(255, 255, 255, 0.95); }
 .bg-yellow-50 { background-color: #fffbeb; }
@@ -77,6 +80,7 @@ img, video {
 .border { border-width: 1px; border-style: solid; }
 .border-b { border-bottom-width: 1px; border-style: solid; }
 .border-dashed { border-style: dashed; }
+.border-gray-100 { border-color: #f1f5f9; }
 .border-gray-200 { border-color: #e5e7eb; }
 .border-gray-300 { border-color: #d1d5db; }
 .border-r { border-right-width: 1px; border-style: solid; }
@@ -87,7 +91,9 @@ img, video {
 .changelist-form-container { overflow-x: auto; }
 .dark .dark\:bg-blue-500\/20 { background-color: rgba(59, 130, 246, 0.2); }
 .dark .dark\:bg-blue-900\/30 { background-color: rgba(30, 58, 138, 0.3); }
+.dark .dark\:bg-gray-700 { background-color: #374151; }
 .dark .dark\:bg-gray-800 { background-color: #1f2937; }
+.dark .dark\:bg-gray-800\/40 { background-color: rgba(31, 41, 55, 0.4); }
 .dark .dark\:bg-gray-800\/50 { background-color: rgba(31, 41, 55, 0.5); }
 .dark .dark\:bg-gray-900 { background-color: #111827; }
 .dark .dark\:bg-gray-900\/40 { background-color: rgba(17, 24, 39, 0.4); }
@@ -98,22 +104,32 @@ img, video {
 .dark .dark\:bg-yellow-900\/30 { background-color: rgba(120, 53, 15, 0.3); }
 .dark .dark\:border-gray-600 { border-color: #4b5563; }
 .dark .dark\:border-gray-700 { border-color: #374151; }
+.dark .dark\:focus\:ring-blue-400:focus { box-shadow: 0 0 0 1px #60a5fa; --fb-focus-ring-color: rgba(96, 165, 250, 0.45); }
 .dark .dark\:focus\:ring-offset-gray-900 { --fb-focus-ring-offset-color: rgba(17, 24, 39, 1); }
 .dark\:focus\:ring-offset-gray-900:focus { outline: none; box-shadow: 0 0 0 var(--fb-focus-ring-offset, 0) var(--fb-focus-ring-offset-color, transparent), 0 0 0 calc(var(--fb-focus-ring-width, 2px) + var(--fb-focus-ring-offset, 0)) var(--fb-focus-ring-color, rgba(59, 130, 246, 0.45)); }
 .dark .dark\:focus\:ring-offset-red-900 { --fb-focus-ring-offset-color: rgba(127, 29, 29, 1); }
 .dark\:focus\:ring-offset-red-900:focus { outline: none; box-shadow: 0 0 0 var(--fb-focus-ring-offset, 0) var(--fb-focus-ring-offset-color, transparent), 0 0 0 calc(var(--fb-focus-ring-width, 2px) + var(--fb-focus-ring-offset, 0)) var(--fb-focus-ring-color, rgba(59, 130, 246, 0.45)); }
+.dark .dark\:group-hover\:bg-blue-900\/30 { background-color: rgba(30, 58, 138, 0.3); }
+.dark .dark\:group-hover\:bg-blue-900\/40 { background-color: rgba(30, 58, 138, 0.4); }
+.dark .dark\:group-hover\:text-blue-300 { color: #93c5fd; }
 .dark .dark\:hover\:bg-gray-700:hover { background-color: #374151; }
+.dark .dark\:hover\:bg-gray-700\/70:hover { background-color: rgba(55, 65, 81, 0.7); }
 .dark .dark\:hover\:bg-gray-800:hover { background-color: #1f2937; }
+.dark .dark\:hover\:bg-gray-800\/80:hover { background-color: rgba(31, 41, 55, 0.8); }
+.dark .dark\:hover\:bg-red-900\/40:hover { background-color: rgba(127, 29, 29, 0.4); }
 .dark .dark\:hover\:text-blue-300:hover { color: #93c5fd; }
+.dark .dark\:hover\:text-gray-200:hover { color: #e5e7eb; }
+.dark .dark\:hover\:text-red-200:hover { color: #fecaca; }
 .dark .dark\:hover\:text-white:hover { color: #ffffff; }
 .dark .dark\:ring-gray-700 { box-shadow: 0 0 0 1px #374151; --fb-focus-ring-color: rgba(55, 65, 81, 0.45); }
 .dark .dark\:text-blue-200 { color: #bfdbfe; }
+.dark .dark\:text-blue-300 { color: #93c5fd; }
 .dark .dark\:text-blue-400 { color: #60a5fa; }
-.dark .dark\:text-gray-100 { color: #f1f5f9; }
 .dark .dark\:text-gray-200 { color: #e5e7eb; }
 .dark .dark\:text-gray-300 { color: #d1d5db; }
 .dark .dark\:text-gray-400 { color: #9ca3af; }
 .dark .dark\:text-gray-500 { color: #6b7280; }
+.dark .dark\:text-gray-600 { color: #4b5563; }
 .dark .dark\:text-green-200 { color: #bbf7d0; }
 .dark .dark\:text-red-200 { color: #fecaca; }
 .dark .dark\:text-white { color: #ffffff; }
@@ -121,9 +137,9 @@ img, video {
 .fixed { position: fixed; }
 .flex { display: flex; }
 .flex-1 { flex: 1 1 0%; }
-.flex-shrink-0 { flex-shrink: 0; }
 .flex-col { flex-direction: column; }
 .flex-wrap { flex-wrap: wrap; }
+.focus\:border-blue-500:focus { border-color: #3b82f6; }
 .focus\:outline-none:focus { outline: none; }
 .focus\:ring-2 { --fb-focus-ring-width: 2px; }
 .focus\:ring-2:focus { outline: none; box-shadow: 0 0 0 var(--fb-focus-ring-offset, 0) var(--fb-focus-ring-offset-color, transparent), 0 0 0 calc(var(--fb-focus-ring-width, 2px) + var(--fb-focus-ring-offset, 0)) var(--fb-focus-ring-color, rgba(59, 130, 246, 0.45)); }
@@ -131,6 +147,7 @@ img, video {
 .focus\:ring-blue-500:focus { outline: none; box-shadow: 0 0 0 var(--fb-focus-ring-offset, 0) var(--fb-focus-ring-offset-color, transparent), 0 0 0 calc(var(--fb-focus-ring-width, 2px) + var(--fb-focus-ring-offset, 0)) var(--fb-focus-ring-color, rgba(59, 130, 246, 0.45)); }
 .focus\:ring-offset-2 { --fb-focus-ring-offset: 2px; }
 .focus\:ring-offset-2:focus { outline: none; box-shadow: 0 0 0 var(--fb-focus-ring-offset, 0) var(--fb-focus-ring-offset-color, transparent), 0 0 0 calc(var(--fb-focus-ring-width, 2px) + var(--fb-focus-ring-offset, 0)) var(--fb-focus-ring-color, rgba(59, 130, 246, 0.45)); }
+.focus\:ring-offset-white:focus { --fb-focus-ring-offset-color: #ffffff; }
 .focus\:ring-red-500 { --fb-focus-ring-color: rgba(239, 68, 68, 0.45); }
 .focus\:ring-red-500:focus { outline: none; box-shadow: 0 0 0 var(--fb-focus-ring-offset, 0) var(--fb-focus-ring-offset-color, transparent), 0 0 0 calc(var(--fb-focus-ring-width, 2px) + var(--fb-focus-ring-offset, 0)) var(--fb-focus-ring-color, rgba(59, 130, 246, 0.45)); }
 .font-bold { font-weight: 700; }
@@ -142,27 +159,25 @@ img, video {
 .gap-4 { gap: 1rem; }
 .gap-6 { gap: 1.5rem; }
 .grid { display: grid; }
-.group { position: relative; }
-.group:hover .group-hover\:bg-blue-100 { background-color: #dbeafe; }
-.group:hover .group-hover\:text-blue-600 { color: #2563eb; }
-.dark .group:hover .dark\:group-hover\:bg-blue-900\/30 { background-color: rgba(30, 58, 138, 0.3); }
-.dark .group:hover .dark\:group-hover\:bg-blue-900\/40 { background-color: rgba(30, 58, 138, 0.4); }
-.dark .group:hover .dark\:group-hover\:text-blue-300 { color: #93c5fd; }
+.group-hover\:text-blue-600 { color: #2563eb; }
 .h-10 { height: 2.5rem; }
 .h-4 { height: 1rem; }
 .h-5 { height: 1.25rem; }
-.h-8 { height: 2rem; }
 .h-full { height: 100%; }
 .h-screen { height: 100vh; }
 .hidden { display: none; }
 .hover\:bg-blue-50:hover { background-color: #eff6ff; }
 .hover\:bg-blue-700:hover { background-color: #1d4ed8; }
 .hover\:bg-gray-100:hover { background-color: #f1f5f9; }
+.hover\:bg-red-50:hover { background-color: #fef2f2; }
 .hover\:bg-red-700:hover { background-color: #b91c1c; }
+.hover\:bg-white:hover { background-color: #ffffff; }
 .hover\:text-blue-500:hover { color: #3b82f6; }
 .hover\:text-blue-600:hover { color: #2563eb; }
 .hover\:text-blue-700:hover { color: #1d4ed8; }
+.hover\:text-gray-700:hover { color: #374151; }
 .hover\:text-gray-900:hover { color: #111827; }
+.hover\:text-red-700:hover { color: #b91c1c; }
 .inline { display: inline; }
 .inline-flex { display: inline-flex; }
 .inset-x-0 { left: 0; right: 0; }
@@ -176,6 +191,7 @@ img, video {
 @media (min-width: 1024px) { .lg\:px-8 { padding-left: 2rem; padding-right: 2rem; } }
 @media (min-width: 1024px) { .lg\:w-72 { width: 18rem; } }
 .list-disc { list-style-type: disc; }
+.list-none { list-style: none; }
 .max-w-full { max-width: 100%; }
 .max-w-md { max-width: 28rem; }
 .mb-4 { margin-bottom: 1rem; }
@@ -196,49 +212,8 @@ img, video {
 .mx-auto { margin-left: auto; margin-right: auto; }
 .object-tools { display: flex; gap: 0.5rem; }
 .overflow-hidden { overflow: hidden; }
-.truncate { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .overflow-x-auto { overflow-x: auto; }
 .overflow-y-auto { overflow-y: auto; }
-.sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0; }
-.with-sidebar-offset { padding-left: 0; }
-@media (min-width: 640px) { .with-sidebar-offset { padding-left: 16rem; } }
-#logo-sidebar { will-change: transform; }
-@media (min-width: 640px) { #logo-sidebar.sidebar-hidden { transform: translateX(-100%); } }
-.topbar-search { display: none; position: relative; align-items: center; width: 100%; max-width: 20rem; }
-@media (min-width: 640px) { .topbar-search { display: flex; } }
-.topbar-search__icon { position: absolute; left: 0.9rem; top: 50%; transform: translateY(-50%); width: 1.1rem; height: 1.1rem; color: #6b7280; }
-.topbar-search__input { width: 100%; padding: 0.5rem 0.75rem 0.5rem 2.5rem; border-radius: 9999px; border: 1px solid #d1d5db; background-color: #f8fafc; color: #111827; font-size: 0.875rem; transition: border-color 150ms ease, box-shadow 150ms ease; }
-.topbar-search__input::placeholder { color: #6b7280; }
-.topbar-search__input:focus { outline: none; border-color: #2563eb; box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.2); background-color: #ffffff; }
-.dark .topbar-search__icon { color: #9ca3af; }
-.dark .topbar-search__input { background-color: #1f2937; border-color: #374151; color: #f3f4f6; }
-.dark .topbar-search__input::placeholder { color: #9ca3af; }
-.dark .topbar-search__input:focus { border-color: #60a5fa; box-shadow: 0 0 0 3px rgba(96, 165, 250, 0.25); background-color: #111827; }
-.topbar-icon-group { display: flex; align-items: center; gap: 0.5rem; }
-.topbar-icon-button { display: inline-flex; align-items: center; justify-content: center; width: 2.5rem; height: 2.5rem; border-radius: 0.75rem; border: 1px solid #e5e7eb; background-color: #ffffff; color: #374151; transition: background-color 150ms ease, color 150ms ease, border-color 150ms ease, box-shadow 150ms ease; }
-.topbar-icon-button:hover { background-color: #eff6ff; color: #1d4ed8; border-color: #bfdbfe; }
-.topbar-icon-button:focus { outline: none; border-color: #2563eb; box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.2); }
-.topbar-icon-button svg { pointer-events: none; }
-.dark .topbar-icon-button { border-color: #374151; background-color: #111827; color: #e5e7eb; }
-.dark .topbar-icon-button:hover { background-color: #1f2937; color: #93c5fd; border-color: #4b5563; }
-.dark .topbar-icon-button:focus { border-color: #60a5fa; box-shadow: 0 0 0 3px rgba(96, 165, 250, 0.25); }
-.topbar-user { display: none; align-items: center; gap: 0.75rem; }
-@media (min-width: 768px) { .topbar-user { display: flex; } }
-.topbar-user__text { display: flex; flex-direction: column; gap: 0.25rem; text-align: right; }
-.topbar-user__greeting { margin: 0; font-size: 0.875rem; font-weight: 600; color: #1f2937; }
-.topbar-user__links { display: flex; flex-wrap: wrap; justify-content: flex-end; gap: 0.35rem; font-size: 0.75rem; color: #4b5563; }
-.topbar-user__link { font-weight: 500; color: #2563eb; text-decoration: none; }
-.topbar-user__link:hover { color: #1d4ed8; }
-.topbar-user__link:focus { outline: none; text-decoration: underline; }
-.topbar-user__logout { background: none; border: none; padding: 0; cursor: pointer; }
-.topbar-user__divider { color: #9ca3af; }
-.topbar-avatar { display: inline-flex; align-items: center; justify-content: center; width: 2.25rem; height: 2.25rem; border-radius: 9999px; background: linear-gradient(135deg, #2563eb, #1d4ed8); color: #ffffff; font-weight: 600; font-size: 0.95rem; text-transform: uppercase; box-shadow: 0 4px 10px rgba(37, 99, 235, 0.25); }
-.dark .topbar-user__greeting { color: #f3f4f6; }
-.dark .topbar-user__links { color: #9ca3af; }
-.dark .topbar-user__link { color: #93c5fd; }
-.dark .topbar-user__link:hover { color: #bfdbfe; }
-.dark .topbar-user__divider { color: #6b7280; }
-.dark .topbar-avatar { background: linear-gradient(135deg, #60a5fa, #2563eb); box-shadow: 0 4px 10px rgba(37, 99, 235, 0.35); }
 .p-2 { padding: 0.5rem; }
 .p-3 { padding: 0.75rem; }
 .p-4 { padding: 1rem; }
@@ -250,25 +225,23 @@ img, video {
 .px-3 { padding-left: 0.75rem; padding-right: 0.75rem; }
 .px-4 { padding-left: 1rem; padding-right: 1rem; }
 .py-1 { padding-top: 0.25rem; padding-bottom: 0.25rem; }
-.py-0\.5 { padding-top: 0.125rem; padding-bottom: 0.125rem; }
 .py-2 { padding-top: 0.5rem; padding-bottom: 0.5rem; }
 .py-3 { padding-top: 0.75rem; padding-bottom: 0.75rem; }
 .py-4 { padding-top: 1rem; padding-bottom: 1rem; }
 .ring-1 { box-shadow: 0 0 0 1px rgba(148, 163, 184, 0.4); }
 .ring-gray-100 { box-shadow: 0 0 0 1px #f1f5f9; --fb-focus-ring-color: rgba(241, 245, 249, 0.45); }
 .rounded-2xl { border-radius: 1rem; }
-.rounded-xl { border-radius: 0.75rem; }
 .rounded-lg { border-radius: 0.5rem; }
 .shadow-sm { box-shadow: 0 1px 2px rgba(15, 23, 42, 0.05); }
 .shadow-xl { box-shadow: 0 20px 25px -5px rgba(15, 23, 42, 0.1), 0 10px 10px -5px rgba(15, 23, 42, 0.04); }
 .shrink-0 { flex-shrink: 0; }
 @media (min-width: 640px) { .sm\:block { display: block; } }
 @media (min-width: 640px) { .sm\:flex-row { flex-direction: row; } }
+@media (min-width: 640px) { .sm\:hidden { display: none; } }
 @media (min-width: 640px) { .sm\:ml-64 { margin-left: 16rem; } }
 @media (min-width: 640px) { .sm\:px-6 { padding-left: 1.5rem; padding-right: 1.5rem; } }
 @media (min-width: 640px) { .sm\:px-8 { padding-left: 2rem; padding-right: 2rem; } }
 @media (min-width: 640px) { .sm\:translate-x-0 { transform: translateX(0); } }
-.space-x-2 > :not([hidden]) ~ :not([hidden]) { margin-left: 0.5rem; }
 .space-y-1 > :not([hidden]) ~ :not([hidden]) { margin-top: 0.25rem; }
 .space-y-2 > :not([hidden]) ~ :not([hidden]) { margin-top: 0.5rem; }
 .space-y-3 > :not([hidden]) ~ :not([hidden]) { margin-top: 0.75rem; }
@@ -289,6 +262,7 @@ img, video {
 .text-gray-900 { color: #111827; }
 .text-green-800 { color: #065f46; }
 .text-lg { font-size: 1.125rem; line-height: 1.75rem; }
+.text-red-600 { color: #dc2626; }
 .text-red-700 { color: #b91c1c; }
 .text-red-800 { color: #991b1b; }
 .text-right { text-align: right; }
@@ -296,24 +270,15 @@ img, video {
 .text-white { color: #ffffff; }
 .text-xl { font-size: 1.25rem; line-height: 1.75rem; }
 .text-xs { font-size: 0.75rem; line-height: 1rem; }
-.text-\[0\.7rem\] { font-size: 0.7rem; line-height: 1rem; }
-.text-\[0\.65rem\] { font-size: 0.65rem; line-height: 0.95rem; }
 .text-yellow-800 { color: #92400e; }
 .top-0 { top: 0; }
 .tracking-wide { letter-spacing: 0.05em; }
-.tracking-widest { letter-spacing: 0.1em; }
-.tracking-\[0\.35em\] { letter-spacing: 0.35em; }
-.tracking-\[0\.3em\] { letter-spacing: 0.3em; }
-.tracking-\[0\.25em\] { letter-spacing: 0.25em; }
 .transition { transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1); }
-.transition-colors { transition-property: color, background-color, border-color, text-decoration-color, fill, stroke; transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1); transition-duration: 150ms; }
-.duration-150 { transition-duration: 150ms; }
 .transition-transform { transition-property: transform; transition-duration: 0.2s; transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1); }
 .uppercase { text-transform: uppercase; }
 .w-10 { width: 2.5rem; }
 .w-4 { width: 1rem; }
 .w-5 { width: 1.25rem; }
-.w-8 { width: 2rem; }
 .w-64 { width: 16rem; }
 .w-full { width: 100%; }
 .z-30 { z-index: 30; }

--- a/tools/build-css.js
+++ b/tools/build-css.js
@@ -318,6 +318,7 @@ function baseDeclaration(base) {
     case 'left-0': return 'left: 0;';
     case 'inset-x-0': return 'left: 0; right: 0;';
     case 'list-disc': return 'list-style-type: disc;';
+    case 'list-none': return 'list-style: none;';
     case 'grid-cols-1': return 'grid-template-columns: repeat(1, minmax(0, 1fr));';
     case 'object-tools': return 'display: flex; gap: 0.5rem;';
     case 'changelist-form-container': return 'overflow-x: auto;';


### PR DESCRIPTION
## Summary
- update the CSS build script to emit a `list-none` declaration
- regenerate the Flowbite Admin stylesheet so the new utility is available

## Testing
- npm run build:css

------
https://chatgpt.com/codex/tasks/task_e_68dc411ad05883268fb12540a8b77c50