### PR TITLE
Allow hyphen-prefixed utilities in CSS build

### DIFF
--- a/flowbite_admin/static/flowbite_admin/css/flowbite-admin.css
+++ b/flowbite_admin/static/flowbite_admin/css/flowbite-admin.css
@@ -61,6 +61,7 @@ img, video {
 /* Generated utility classes */
 :root { --fb-focus-ring-width: 2px; --fb-focus-ring-offset: 0; --fb-focus-ring-color: rgba(59, 130, 246, 0.45); --fb-focus-ring-offset-color: transparent; }
 .dark :focus { box-shadow: 0 0 0 var(--fb-focus-ring-width, 2px) var(--fb-focus-ring-color, rgba(59, 130, 246, 0.45)); }
+.-translate-x-full { transform: translateX(-100%); }
 .backdrop-blur { backdrop-filter: blur(8px); }
 .bg-blue-50 { background-color: #eff6ff; }
 .bg-blue-600 { background-color: #2563eb; }

--- a/tools/build-css.js
+++ b/tools/build-css.js
@@ -208,7 +208,7 @@ function extractClassesFrom(content) {
       if (!cleaned) continue;
       if (cleaned.includes('{') || cleaned.includes('}') || cleaned.includes('%')) continue;
       if (cleaned.startsWith('if') || cleaned.startsWith('elif') || cleaned.startsWith('endif') || cleaned.startsWith('for') || cleaned.startsWith('endfor')) continue;
-      if (!/^[A-Za-z0-9].*[A-Za-z0-9\]]$/.test(cleaned)) continue;
+      if (!/^-?[A-Za-z0-9].*[A-Za-z0-9\]]$/.test(cleaned)) continue;
       classes.add(cleaned);
     }
   }


### PR DESCRIPTION
## Summary
- relax the class name validation so utility classes can start with a hyphen
- rebuild the generated Flowbite Admin CSS so the -translate-x-full helper is emitted

## Testing
- npm run build:css

------
https://chatgpt.com/codex/tasks/task_e_68dc44624ab88326b74e13cef80b33ee