### PR TITLE
Update admin header logo rendering

### DIFF
--- a/flowbite_admin/static/admin/img/logo.svg
+++ b/flowbite_admin/static/admin/img/logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40" role="img" aria-hidden="true">
+  <rect width="40" height="40" rx="12" fill="#2563EB" />
+  <path fill="#FFFFFF" d="M11 28V12h8.2c2.5 0 4.2 1.5 4.2 3.9c0 1.8-.9 3.1-2.6 3.6c2 0.4 3.2 1.8 3.2 4c0 2.7-1.8 4.5-4.7 4.5H11zm7.7-9c1.6 0 2.5-.8 2.5-2.1c0-1.3-.8-2-2.5-2H14v4.1h4.7zm.3 7c1.8 0 2.8-1 2.8-2.5s-1-2.4-2.8-2.4H14V26h5z" />
+</svg>

--- a/flowbite_admin/static/flowbite_admin/css/flowbite-admin.css
+++ b/flowbite_admin/static/flowbite_admin/css/flowbite-admin.css
@@ -152,7 +152,6 @@ img, video {
 .focus\:ring-offset-white:focus { --fb-focus-ring-offset-color: #ffffff; }
 .focus\:ring-red-500 { --fb-focus-ring-color: rgba(239, 68, 68, 0.45); }
 .focus\:ring-red-500:focus { outline: none; box-shadow: 0 0 0 var(--fb-focus-ring-offset, 0) var(--fb-focus-ring-offset-color, transparent), 0 0 0 calc(var(--fb-focus-ring-width, 2px) + var(--fb-focus-ring-offset, 0)) var(--fb-focus-ring-color, rgba(59, 130, 246, 0.45)); }
-.font-bold { font-weight: 700; }
 .font-medium { font-weight: 500; }
 .font-semibold { font-weight: 600; }
 .gap-1 { gap: 0.25rem; }
@@ -162,9 +161,9 @@ img, video {
 .gap-6 { gap: 1.5rem; }
 .grid { display: grid; }
 .group-hover\:text-blue-600 { color: #2563eb; }
-.h-10 { height: 2.5rem; }
 .h-4 { height: 1rem; }
 .h-5 { height: 1.25rem; }
+.h-8 { height: 2rem; }
 .h-full { height: 100%; }
 .h-screen { height: 100vh; }
 .hidden { display: none; }
@@ -247,6 +246,7 @@ img, video {
 @media (min-width: 640px) { .sm\:px-6 { padding-left: 1.5rem; padding-right: 1.5rem; } }
 @media (min-width: 640px) { .sm\:px-8 { padding-left: 2rem; padding-right: 2rem; } }
 @media (min-width: 640px) { .sm\:translate-x-0 { transform: translateX(0); } }
+.space-x-3 > :not([hidden]) ~ :not([hidden]) { margin-left: 0.75rem; }
 .space-y-1 > :not([hidden]) ~ :not([hidden]) { margin-top: 0.25rem; }
 .space-y-2 > :not([hidden]) ~ :not([hidden]) { margin-top: 0.5rem; }
 .space-y-3 > :not([hidden]) ~ :not([hidden]) { margin-top: 0.75rem; }
@@ -281,10 +281,10 @@ img, video {
 .transition { transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1); }
 .transition-transform { transition-property: transform; transition-duration: 0.2s; transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1); }
 .uppercase { text-transform: uppercase; }
-.w-10 { width: 2.5rem; }
 .w-4 { width: 1rem; }
 .w-5 { width: 1.25rem; }
 .w-64 { width: 16rem; }
+.w-auto { width: auto; }
 .w-full { width: 100%; }
 .z-30 { z-index: 30; }
 .z-40 { z-index: 40; }

--- a/flowbite_admin/templates/admin/base_site.html
+++ b/flowbite_admin/templates/admin/base_site.html
@@ -40,8 +40,8 @@
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4 6h16M4 12h16M4 18h16" />
         </svg>
       </button>
-      <a href="{% url 'admin:index' %}" class="flex items-center gap-2 text-xl font-semibold text-gray-900 dark:text-white">
-        <span class="inline-flex h-10 w-10 items-center justify-center rounded-lg bg-blue-600 text-lg font-bold text-white">{% firstof site_header 'FB' %}</span>
+      <a href="{% url 'admin:index' %}" class="flex items-center space-x-3 text-xl font-semibold text-gray-900 dark:text-white">
+        <img src="{% static 'admin/img/logo.svg' %}" alt="" class="h-8 w-auto">
         <span class="hidden md:inline">{% firstof site_title site_header _('Flowbite Admin') %}</span>
       </a>
     </div>

--- a/tools/build-css.js
+++ b/tools/build-css.js
@@ -278,11 +278,13 @@ function baseDeclaration(base) {
     case 'mb-6': return 'margin-bottom: 1.5rem;';
     case 'min-h-[70vh]': return 'min-height: 70vh;';
     case 'w-full': return 'width: 100%;';
+    case 'w-auto': return 'width: auto;';
     case 'w-64': return 'width: 16rem;';
     case 'w-10': return 'width: 2.5rem;';
     case 'w-5': return 'width: 1.25rem;';
     case 'w-4': return 'width: 1rem;';
     case 'h-10': return 'height: 2.5rem;';
+    case 'h-8': return 'height: 2rem;';
     case 'h-5': return 'height: 1.25rem;';
     case 'h-4': return 'height: 1rem;';
     case 'h-full': return 'height: 100%;';


### PR DESCRIPTION
## Summary
- replace the admin header monogram with the packaged logo image while keeping the site title text
- extend the CSS build script with the sizing utilities needed for the logo/text layout and regenerate the bundle
- add the admin logo asset so the header renders correctly in both light and dark themes

## Testing
- npm run build:css
- DJANGO_SETTINGS_MODULE=tests.settings pytest *(fails: Apps aren't loaded yet with in-memory SQLite settings)*

------
https://chatgpt.com/codex/tasks/task_e_68dc48e8222c83268ed5f0684ff2072c