### PR TITLE
Enhance theme toggle contrast

### DIFF
--- a/flowbite_admin/static/flowbite_admin/css/flowbite-admin.css
+++ b/flowbite_admin/static/flowbite_admin/css/flowbite-admin.css
@@ -103,6 +103,7 @@ img, video {
 .dark .dark\:bg-gray-900\/95 { background-color: rgba(17, 24, 39, 0.95); }
 .dark .dark\:bg-green-900\/30 { background-color: rgba(6, 78, 59, 0.3); }
 .dark .dark\:bg-red-900\/30 { background-color: rgba(127, 29, 29, 0.3); }
+.dark .dark\:bg-yellow-400 { background-color: #fbbf24; }
 .dark .dark\:bg-yellow-900\/30 { background-color: rgba(120, 53, 15, 0.3); }
 .dark .dark\:border-gray-600 { border-color: #4b5563; }
 .dark .dark\:border-gray-700 { border-color: #374151; }
@@ -119,6 +120,7 @@ img, video {
 .dark .dark\:hover\:bg-gray-800:hover { background-color: #1f2937; }
 .dark .dark\:hover\:bg-gray-800\/80:hover { background-color: rgba(31, 41, 55, 0.8); }
 .dark .dark\:hover\:bg-red-900\/40:hover { background-color: rgba(127, 29, 29, 0.4); }
+.dark .dark\:hover\:bg-yellow-300:hover { background-color: #fcd34d; }
 .dark .dark\:hover\:text-blue-300:hover { color: #93c5fd; }
 .dark .dark\:hover\:text-gray-200:hover { color: #e5e7eb; }
 .dark .dark\:hover\:text-red-200:hover { color: #fecaca; }
@@ -132,6 +134,7 @@ img, video {
 .dark .dark\:text-gray-400 { color: #9ca3af; }
 .dark .dark\:text-gray-500 { color: #6b7280; }
 .dark .dark\:text-gray-600 { color: #4b5563; }
+.dark .dark\:text-gray-900 { color: #111827; }
 .dark .dark\:text-green-200 { color: #bbf7d0; }
 .dark .dark\:text-red-200 { color: #fecaca; }
 .dark .dark\:text-white { color: #ffffff; }

--- a/flowbite_admin/templates/admin/base_site.html
+++ b/flowbite_admin/templates/admin/base_site.html
@@ -68,7 +68,9 @@
           </svg>
         </button>
       </div>
-      <button id="theme-toggle" type="button" class="topbar-icon-button" aria-label="{% translate 'Toggle dark mode' %}">
+      <button id="theme-toggle" type="button"
+        class="topbar-icon-button bg-blue-600 text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-white dark:bg-yellow-400 dark:text-gray-900 dark:hover:bg-yellow-300 dark:focus:ring-blue-400 dark:focus:ring-offset-gray-900"
+        aria-label="{% translate 'Toggle dark mode' %}">
         <svg id="theme-toggle-dark-icon" class="hidden h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
           <path d="M17.293 13.293a8 8 0 11-10.586-10.586 8.001 8.001 0 1010.586 10.586z" />
         </svg>

--- a/tools/build-css.js
+++ b/tools/build-css.js
@@ -113,6 +113,8 @@ const colorMap = {
   'red-900': '#7f1d1d',
   'yellow-50': '#fffbeb',
   'yellow-200': '#fde68a',
+  'yellow-300': '#fcd34d',
+  'yellow-400': '#fbbf24',
   'yellow-800': '#92400e',
   'yellow-900': '#78350f'
 };


### PR DESCRIPTION
## Summary
- add high-contrast light and dark theme styles to the header theme toggle
- extend the CSS build script color map to cover the new yellow utilities
- regenerate the compiled stylesheet so the new utility classes are available

## Testing
- node tools/build-css.js

------
https://chatgpt.com/codex/tasks/task_e_68dc4c09872883268e8857b0e2e0a3e5