### PR TITLE
Align admin UI controls with Flowbite components

### DIFF
--- a/flowbite_admin/static/flowbite_admin/css/flowbite-admin.css
+++ b/flowbite_admin/static/flowbite_admin/css/flowbite-admin.css
@@ -291,3 +291,5 @@ img, video {
 .w-full { width: 100%; }
 .z-30 { z-index: 30; }
 .z-40 { z-index: 40; }
+[data-dropdown-toggle][aria-expanded="true"] [data-dropdown-arrow] { transform: rotate(180deg); }
+button[aria-expanded="true"] [data-accordion-icon] { transform: rotate(180deg); }

--- a/flowbite_admin/static/flowbite_admin/js/flowbite-admin.js
+++ b/flowbite_admin/static/flowbite_admin/js/flowbite-admin.js
@@ -1,213 +1,230 @@
-document.addEventListener('DOMContentLoaded', () => {
-  initSidebarDrawer();
-  initSidebarAccordion();
-  initUserMenu();
-  initFullscreenToggle();
-});
-
-function initSidebarDrawer() {
-  const sidebar = document.getElementById('logo-sidebar');
-  if (!sidebar) {
-    return;
-  }
-
-  const toggleButtons = document.querySelectorAll('[data-drawer-target="logo-sidebar"]');
-  const overlay = document.getElementById('sidebar-backdrop');
-  const smMediaQuery = window.matchMedia('(min-width: 640px)');
-
-  const setAriaExpanded = (isExpanded) => {
-    toggleButtons.forEach((button) => {
-      button.setAttribute('aria-expanded', String(isExpanded));
-    });
-  };
-
-  const openSidebar = () => {
-    sidebar.classList.remove('sidebar-hidden');
-    sidebar.classList.remove('-translate-x-full');
-    if (!smMediaQuery.matches) {
-      overlay?.classList.remove('hidden');
-      document.body.classList.add('overflow-hidden');
-    } else {
-      overlay?.classList.add('hidden');
-      document.body.classList.remove('overflow-hidden');
+(function () {
+  document.addEventListener('DOMContentLoaded', function () {
+    if (typeof window.initFlowbite === 'function') {
+      window.initFlowbite();
     }
-    setAriaExpanded(true);
-  };
 
-  const closeSidebar = () => {
-    sidebar.classList.add('sidebar-hidden');
-    sidebar.classList.add('-translate-x-full');
-    overlay?.classList.add('hidden');
-    document.body.classList.remove('overflow-hidden');
-    setAriaExpanded(false);
-  };
-
-  const toggleSidebar = () => {
-    const isOpen = !sidebar.classList.contains('-translate-x-full');
-    if (isOpen) {
-      closeSidebar();
-    } else {
-      openSidebar();
-    }
-  };
-
-  toggleButtons.forEach((button) => {
-    button.addEventListener('click', toggleSidebar);
+    initThemeToggle();
+    initFullscreenToggle();
+    initSidebarAccordionBreakpointSync();
+    initDrawerAriaSync();
   });
 
-  overlay?.addEventListener('click', closeSidebar);
-
-  document.addEventListener('keydown', (event) => {
-    if (event.key === 'Escape') {
-      closeSidebar();
-    }
-  });
-
-  const handleBreakpointChange = (event) => {
-    if (event.matches) {
-      openSidebar();
-    } else {
-      closeSidebar();
-    }
-  };
-
-  smMediaQuery.addEventListener('change', handleBreakpointChange);
-  handleBreakpointChange(smMediaQuery);
-}
-
-function initSidebarAccordion() {
-  const sidebar = document.getElementById('logo-sidebar');
-  if (!sidebar) {
-    return;
-  }
-
-  const smMediaQuery = window.matchMedia('(min-width: 640px)');
-
-  sidebar.querySelectorAll('[data-sidebar-accordion-toggle]').forEach((toggle) => {
-    const targetId = toggle.getAttribute('aria-controls');
-    if (!targetId) {
+  function initThemeToggle() {
+    const toggle = document.querySelector('[data-theme-toggle]');
+    if (!toggle) {
       return;
     }
-    const panel = document.getElementById(targetId);
-    if (!panel) {
-      return;
-    }
-    const arrow = toggle.querySelector('[data-sidebar-accordion-arrow]');
 
-    const setState = (expanded) => {
-      toggle.setAttribute('aria-expanded', String(expanded));
-      panel.classList.toggle('hidden', !expanded);
-      if (arrow) {
-        arrow.classList.toggle('rotate-180', expanded);
-      }
+    const icons = {
+      dark: toggle.querySelector('[data-theme-toggle-icon="dark"]'),
+      light: toggle.querySelector('[data-theme-toggle-icon="light"]'),
     };
 
-    const initialExpanded = smMediaQuery.matches;
-    setState(initialExpanded);
+    const prefersDarkMedia = window.matchMedia('(prefers-color-scheme: dark)');
 
-    toggle.addEventListener('click', () => {
-      const isExpanded = toggle.getAttribute('aria-expanded') === 'true';
-      setState(!isExpanded);
-    });
-
-    smMediaQuery.addEventListener('change', (event) => {
-      if (event.matches) {
-        setState(true);
+    function setIcons(isDark) {
+      if (icons.dark) {
+        icons.dark.classList.toggle('hidden', isDark);
       }
+      if (icons.light) {
+        icons.light.classList.toggle('hidden', !isDark);
+      }
+    }
+
+    function applyTheme(isDark, persist = true) {
+      document.documentElement.classList.toggle('dark', isDark);
+      toggle.setAttribute('aria-pressed', String(isDark));
+      if (persist) {
+        localStorage.setItem('color-theme', isDark ? 'dark' : 'light');
+      }
+      setIcons(isDark);
+    }
+
+    function resolvePreferredTheme() {
+      const storedTheme = localStorage.getItem('color-theme');
+      if (storedTheme === 'dark') {
+        return true;
+      }
+      if (storedTheme === 'light') {
+        return false;
+      }
+      return prefersDarkMedia.matches;
+    }
+
+    applyTheme(resolvePreferredTheme(), false);
+
+    toggle.addEventListener('click', function (event) {
+      event.preventDefault();
+      const isDark = document.documentElement.classList.contains('dark');
+      applyTheme(!isDark);
     });
-  });
-}
 
-function initUserMenu() {
-  const button = document.getElementById('user-menu-button');
-  const menu = document.getElementById('user-menu');
-  if (!button || !menu) {
-    return;
-  }
-
-  const arrow = button.querySelector('[data-dropdown-arrow]');
-
-  const openMenu = () => {
-    menu.classList.remove('hidden');
-    button.setAttribute('aria-expanded', 'true');
-    arrow?.classList.add('rotate-180');
-  };
-
-  const closeMenu = () => {
-    menu.classList.add('hidden');
-    button.setAttribute('aria-expanded', 'false');
-    arrow?.classList.remove('rotate-180');
-  };
-
-  const toggleMenu = () => {
-    if (menu.classList.contains('hidden')) {
-      openMenu();
-    } else {
-      closeMenu();
-    }
-  };
-
-  button.addEventListener('click', (event) => {
-    event.preventDefault();
-    toggleMenu();
-  });
-
-  document.addEventListener('click', (event) => {
-    if (!menu.contains(event.target) && !button.contains(event.target)) {
-      closeMenu();
-    }
-  });
-
-  document.addEventListener('keydown', (event) => {
-    if (event.key === 'Escape') {
-      closeMenu();
-    }
-  });
-}
-
-function initFullscreenToggle() {
-  const button = document.querySelector('[data-action="toggle-fullscreen"]');
-  if (!button) {
-    return;
-  }
-
-  const labels = {
-    enter: button.getAttribute('data-fullscreen-label-enter') || 'Enter fullscreen',
-    exit: button.getAttribute('data-fullscreen-label-exit') || 'Exit fullscreen',
-  };
-
-  if (!document.documentElement.requestFullscreen || !document.exitFullscreen || !document.fullscreenEnabled) {
-    button.setAttribute('aria-pressed', 'false');
-    button.setAttribute('aria-label', labels.enter);
-    button.setAttribute('disabled', 'disabled');
-    button.classList.add('cursor-not-allowed', 'opacity-60');
-    return;
-  }
-
-  const updateButtonState = () => {
-    const isFullscreen = Boolean(document.fullscreenElement);
-    button.setAttribute('aria-pressed', String(isFullscreen));
-    button.setAttribute('aria-label', isFullscreen ? labels.exit : labels.enter);
-    button.classList.toggle('is-fullscreen', isFullscreen);
-  };
-
-  const toggleFullscreen = () => {
-    if (document.fullscreenElement) {
-      document.exitFullscreen().catch(() => {
-        updateButtonState();
+    if (typeof prefersDarkMedia.addEventListener === 'function') {
+      prefersDarkMedia.addEventListener('change', function (event) {
+        if (localStorage.getItem('color-theme')) {
+          return;
+        }
+        applyTheme(event.matches, false);
       });
-    } else {
-      document.documentElement.requestFullscreen().catch(() => {
-        updateButtonState();
+    } else if (typeof prefersDarkMedia.addListener === 'function') {
+      prefersDarkMedia.addListener(function (event) {
+        if (localStorage.getItem('color-theme')) {
+          return;
+        }
+        applyTheme(event.matches, false);
       });
     }
-  };
+  }
 
-  button.addEventListener('click', (event) => {
-    event.preventDefault();
-    toggleFullscreen();
-  });
+  function initFullscreenToggle() {
+    const button = document.querySelector('[data-action="toggle-fullscreen"]');
+    if (!button) {
+      return;
+    }
 
-  document.addEventListener('fullscreenchange', updateButtonState);
-  updateButtonState();
-}
+    const labels = {
+      enter: button.getAttribute('data-fullscreen-label-enter') || 'Enter fullscreen',
+      exit: button.getAttribute('data-fullscreen-label-exit') || 'Exit fullscreen',
+    };
+
+    if (!document.documentElement.requestFullscreen || !document.exitFullscreen || !document.fullscreenEnabled) {
+      button.setAttribute('aria-pressed', 'false');
+      button.setAttribute('aria-label', labels.enter);
+      button.setAttribute('disabled', 'disabled');
+      button.classList.add('cursor-not-allowed', 'opacity-60');
+      return;
+    }
+
+    function updateButtonState() {
+      const isFullscreen = Boolean(document.fullscreenElement);
+      button.setAttribute('aria-pressed', String(isFullscreen));
+      button.setAttribute('aria-label', isFullscreen ? labels.exit : labels.enter);
+      button.classList.toggle('is-fullscreen', isFullscreen);
+    }
+
+    function toggleFullscreen() {
+      if (document.fullscreenElement) {
+        document.exitFullscreen().catch(function () {
+          updateButtonState();
+        });
+      } else {
+        document.documentElement.requestFullscreen().catch(function () {
+          updateButtonState();
+        });
+      }
+    }
+
+    button.addEventListener('click', function (event) {
+      event.preventDefault();
+      toggleFullscreen();
+    });
+
+    document.addEventListener('fullscreenchange', updateButtonState);
+    updateButtonState();
+  }
+
+  function initSidebarAccordionBreakpointSync() {
+    const accordionContainer = document.getElementById('sidebar-accordion');
+    if (!accordionContainer) {
+      return;
+    }
+
+    const triggers = accordionContainer.querySelectorAll('[data-accordion-target]');
+    if (!triggers.length) {
+      return;
+    }
+
+    const smMediaQuery = window.matchMedia('(min-width: 640px)');
+
+    function setExpanded(trigger, expanded) {
+      trigger.setAttribute('aria-expanded', String(expanded));
+      const targetSelector = trigger.getAttribute('data-accordion-target');
+      if (!targetSelector) {
+        return;
+      }
+      const target = accordionContainer.querySelector(targetSelector);
+      if (!target) {
+        return;
+      }
+      target.classList.toggle('hidden', !expanded);
+    }
+
+    function expandAll() {
+      triggers.forEach(function (trigger) {
+        setExpanded(trigger, true);
+      });
+    }
+
+    function handleBreakpointChange(event) {
+      if (event.matches) {
+        expandAll();
+      }
+    }
+
+    if (smMediaQuery.matches) {
+      expandAll();
+    }
+
+    if (typeof smMediaQuery.addEventListener === 'function') {
+      smMediaQuery.addEventListener('change', handleBreakpointChange);
+    } else if (typeof smMediaQuery.addListener === 'function') {
+      smMediaQuery.addListener(handleBreakpointChange);
+    }
+  }
+
+  function initDrawerAriaSync() {
+    const drawer = document.getElementById('logo-sidebar');
+    if (!drawer) {
+      return;
+    }
+
+    const triggers = document.querySelectorAll('[data-drawer-toggle="logo-sidebar"], [data-drawer-target="logo-sidebar"]');
+    if (!triggers.length) {
+      return;
+    }
+
+    const overlay = document.getElementById('sidebar-backdrop');
+    const smMediaQuery = window.matchMedia('(min-width: 640px)');
+
+    function updateExpandedState(isExpanded) {
+      triggers.forEach(function (trigger) {
+        trigger.setAttribute('aria-expanded', String(isExpanded));
+      });
+      const shouldLockScroll = isExpanded && !smMediaQuery.matches;
+      if (overlay) {
+        overlay.classList.toggle('hidden', !shouldLockScroll);
+      }
+      document.body.classList.toggle('overflow-hidden', shouldLockScroll);
+    }
+
+    const observer = new MutationObserver(function () {
+      const isExpanded = !drawer.classList.contains('-translate-x-full');
+      updateExpandedState(isExpanded);
+    });
+
+    observer.observe(drawer, { attributes: true, attributeFilter: ['class'] });
+    function syncForBreakpoint(event) {
+      if (event.matches) {
+        drawer.classList.remove('-translate-x-full');
+      } else {
+        drawer.classList.add('-translate-x-full');
+      }
+      updateExpandedState(!drawer.classList.contains('-translate-x-full'));
+    }
+
+    syncForBreakpoint(smMediaQuery);
+    if (typeof smMediaQuery.addEventListener === 'function') {
+      smMediaQuery.addEventListener('change', syncForBreakpoint);
+    } else if (typeof smMediaQuery.addListener === 'function') {
+      smMediaQuery.addListener(syncForBreakpoint);
+    }
+
+    if (overlay) {
+      overlay.addEventListener('click', function (event) {
+        event.preventDefault();
+        drawer.classList.add('-translate-x-full');
+      });
+    }
+  }
+})();

--- a/flowbite_admin/static/flowbite_admin/js/flowbite.min.js
+++ b/flowbite_admin/static/flowbite_admin/js/flowbite.min.js
@@ -1,50 +1,230 @@
-/*! Minimal Flowbite drawer support for Django Flowbite Admin */
-(function(){
-  function toggleDrawer(target, isOpen){
-    if(!target)return;
-    var hiddenClass='-translate-x-full';
-    if(typeof isOpen!=='boolean'){
-      isOpen=target.classList.contains(hiddenClass);
-    }
-    if(isOpen){
-      target.classList.remove(hiddenClass);
-    }else{
-      target.classList.add(hiddenClass);
-    }
+/*! Lightweight Flowbite helpers for Django Flowbite Admin */
+(function () {
+  var HIDDEN_CLASS = 'hidden';
+  var DRAWER_HIDDEN_CLASS = '-translate-x-full';
+
+  function Drawer(element) {
+    this.el = element;
   }
-  function closeDrawer(target){
-    if(!target)return;
-    target.classList.add('-translate-x-full');
+
+  Drawer.prototype.isVisible = function () {
+    return !this.el.classList.contains(DRAWER_HIDDEN_CLASS);
+  };
+
+  Drawer.prototype.show = function () {
+    this.el.classList.remove(DRAWER_HIDDEN_CLASS);
+    this.dispatch('show');
+  };
+
+  Drawer.prototype.hide = function () {
+    this.el.classList.add(DRAWER_HIDDEN_CLASS);
+    this.dispatch('hide');
+  };
+
+  Drawer.prototype.toggle = function () {
+    if (this.isVisible()) {
+      this.hide();
+    } else {
+      this.show();
+    }
+  };
+
+  Drawer.prototype.dispatch = function (type) {
+    if (typeof window.CustomEvent !== 'function') {
+      return;
+    }
+    this.el.dispatchEvent(new CustomEvent(type + '.tw.drawer', { detail: { drawer: this } }));
+  };
+
+  function Accordion(container) {
+    this.container = container;
+    this.triggers = Array.prototype.slice.call(container.querySelectorAll('[data-accordion-target]'));
   }
-  function init(){
-    var triggers=document.querySelectorAll('[data-drawer-toggle]');
-    triggers.forEach(function(trigger){
-      var targetId=trigger.getAttribute('data-drawer-toggle')||trigger.getAttribute('data-drawer-target');
-      if(!targetId)return;
-      var target=document.getElementById(targetId);
-      if(!target)return;
-      trigger.addEventListener('click',function(event){
+
+  Accordion.prototype.init = function () {
+    var _this = this;
+    this.triggers.forEach(function (trigger) {
+      if (trigger.__flowbiteAccordionBound) {
+        return;
+      }
+      trigger.__flowbiteAccordionBound = true;
+      var targetSelector = trigger.getAttribute('data-accordion-target');
+      if (!targetSelector) {
+        return;
+      }
+      var target = _this.container.querySelector(targetSelector);
+      if (!target) {
+        return;
+      }
+      trigger.addEventListener('click', function (event) {
         event.preventDefault();
-        var isHidden=target.classList.contains('-translate-x-full');
-        toggleDrawer(target,isHidden);
-        trigger.setAttribute('aria-expanded',String(isHidden));
+        var isExpanded = trigger.getAttribute('aria-expanded') === 'true';
+        if (isExpanded) {
+          trigger.setAttribute('aria-expanded', 'false');
+          target.classList.add(HIDDEN_CLASS);
+        } else {
+          trigger.setAttribute('aria-expanded', 'true');
+          target.classList.remove(HIDDEN_CLASS);
+        }
       });
     });
-    document.addEventListener('keydown',function(event){
-      if(event.key==='Escape'){
-        document.querySelectorAll('[data-drawer-toggle]').forEach(function(trigger){
-          var targetId=trigger.getAttribute('data-drawer-toggle')||trigger.getAttribute('data-drawer-target');
-          if(!targetId)return;
-          var target=document.getElementById(targetId);
-          closeDrawer(target);
-          trigger.setAttribute('aria-expanded','false');
-        });
+  };
+
+  function Dropdown(trigger, menu) {
+    this.trigger = trigger;
+    this.menu = menu;
+    this.handleDocumentClick = this.handleDocumentClick.bind(this);
+    this.handleEscape = this.handleEscape.bind(this);
+  }
+
+  Dropdown.prototype.isOpen = function () {
+    return !this.menu.classList.contains(HIDDEN_CLASS);
+  };
+
+  Dropdown.prototype.show = function () {
+    this.menu.classList.remove(HIDDEN_CLASS);
+    this.trigger.setAttribute('aria-expanded', 'true');
+    document.addEventListener('click', this.handleDocumentClick);
+    document.addEventListener('keydown', this.handleEscape);
+  };
+
+  Dropdown.prototype.hide = function () {
+    this.menu.classList.add(HIDDEN_CLASS);
+    this.trigger.setAttribute('aria-expanded', 'false');
+    document.removeEventListener('click', this.handleDocumentClick);
+    document.removeEventListener('keydown', this.handleEscape);
+  };
+
+  Dropdown.prototype.toggle = function () {
+    if (this.isOpen()) {
+      this.hide();
+    } else {
+      this.show();
+    }
+  };
+
+  Dropdown.prototype.handleDocumentClick = function (event) {
+    if (this.menu.contains(event.target) || this.trigger.contains(event.target)) {
+      return;
+    }
+    this.hide();
+  };
+
+  Dropdown.prototype.handleEscape = function (event) {
+    if (event.key === 'Escape') {
+      this.hide();
+    }
+  };
+
+  function initDrawers() {
+    var drawerInstances = new Map();
+
+    function getDrawerInstance(target) {
+      if (!target) {
+        return null;
       }
+      if (!drawerInstances.has(target)) {
+        drawerInstances.set(target, new Drawer(target));
+      }
+      return drawerInstances.get(target);
+    }
+
+    var triggers = document.querySelectorAll('[data-drawer-toggle]');
+    triggers.forEach(function (trigger) {
+      if (trigger.__flowbiteDrawerBound) {
+        return;
+      }
+      trigger.__flowbiteDrawerBound = true;
+      var targetId = trigger.getAttribute('data-drawer-target') || trigger.getAttribute('data-drawer-toggle');
+      if (!targetId) {
+        return;
+      }
+      var target = document.getElementById(targetId);
+      if (!target) {
+        return;
+      }
+      var instance = getDrawerInstance(target);
+      trigger.addEventListener('click', function (event) {
+        event.preventDefault();
+        instance.toggle();
+      });
+    });
+
+    var closeTriggers = document.querySelectorAll('[data-drawer-hide]');
+    closeTriggers.forEach(function (trigger) {
+      if (trigger.__flowbiteDrawerHideBound) {
+        return;
+      }
+      trigger.__flowbiteDrawerHideBound = true;
+      var targetId = trigger.getAttribute('data-drawer-hide');
+      if (!targetId) {
+        return;
+      }
+      var target = document.getElementById(targetId);
+      if (!target) {
+        return;
+      }
+      var instance = getDrawerInstance(target);
+      trigger.addEventListener('click', function (event) {
+        event.preventDefault();
+        instance.hide();
+      });
+    });
+
+    document.addEventListener('keydown', function (event) {
+      if (event.key !== 'Escape') {
+        return;
+      }
+      drawerInstances.forEach(function (instance) {
+        if (instance.isVisible()) {
+          instance.hide();
+        }
+      });
     });
   }
-  if(document.readyState==='loading'){
-    document.addEventListener('DOMContentLoaded',init);
-  }else{
-    init();
+
+  function initAccordions() {
+    var containers = document.querySelectorAll('[data-accordion]');
+    containers.forEach(function (container) {
+      var accordion = new Accordion(container);
+      accordion.init();
+    });
   }
+
+  function initDropdowns() {
+    var triggers = document.querySelectorAll('[data-dropdown-toggle]');
+    triggers.forEach(function (trigger) {
+      if (trigger.__flowbiteDropdownBound) {
+        return;
+      }
+      trigger.__flowbiteDropdownBound = true;
+      var menuId = trigger.getAttribute('data-dropdown-toggle');
+      if (!menuId) {
+        return;
+      }
+      var menu = document.getElementById(menuId);
+      if (!menu) {
+        return;
+      }
+      var dropdown = new Dropdown(trigger, menu);
+      trigger.addEventListener('click', function (event) {
+        event.preventDefault();
+        dropdown.toggle();
+      });
+    });
+  }
+
+  function initFlowbite() {
+    initDrawers();
+    initAccordions();
+    initDropdowns();
+  }
+
+  window.initFlowbite = initFlowbite;
+  window.Flowbite = window.Flowbite || {
+    Drawer: Drawer,
+    Accordion: Accordion,
+    Dropdown: Dropdown,
+    init: initFlowbite,
+  };
 })();

--- a/flowbite_admin/templates/admin/base_site.html
+++ b/flowbite_admin/templates/admin/base_site.html
@@ -18,9 +18,9 @@
   {{ block.super }}
   <script>
     (function () {
-      const colorTheme = localStorage.getItem('color-theme');
+      const storedTheme = localStorage.getItem('color-theme');
       const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-      if (colorTheme === 'dark' || (!colorTheme && prefersDark)) {
+      if (storedTheme === 'dark' || (!storedTheme && prefersDark)) {
         document.documentElement.classList.add('dark');
       } else {
         document.documentElement.classList.remove('dark');
@@ -35,7 +35,7 @@
 <header class="fixed inset-x-0 top-0 z-30 border-b border-gray-200 bg-white/95 backdrop-blur dark:border-gray-700 dark:bg-gray-900/95 with-sidebar-offset">
   <div class="mx-auto flex max-w-full items-center justify-between px-4 py-3 sm:px-6 lg:px-8">
     <div class="flex items-center gap-3">
-      <button type="button" class="inline-flex items-center rounded-lg border border-gray-200 p-2 text-sm text-gray-500 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-800" data-drawer-target="logo-sidebar" data-drawer-toggle="logo-sidebar" aria-controls="logo-sidebar" aria-expanded="false" aria-label="{% translate 'Toggle navigation' %}">
+      <button type="button" class="inline-flex items-center rounded-lg border border-gray-200 p-2 text-sm text-gray-500 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-800" data-drawer-target="logo-sidebar" data-drawer-toggle="logo-sidebar" data-drawer-placement="left" aria-controls="logo-sidebar" aria-expanded="false" aria-label="{% translate 'Toggle navigation' %}">
         <svg class="h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4 6h16M4 12h16M4 18h16" />
         </svg>
@@ -70,11 +70,12 @@
       </div>
       <button id="theme-toggle" type="button"
         class="topbar-icon-button bg-blue-600 text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:ring-offset-white dark:bg-yellow-400 dark:text-gray-900 dark:hover:bg-yellow-300 dark:focus:ring-blue-400 dark:focus:ring-offset-gray-900"
+        data-theme-toggle aria-pressed="false"
         aria-label="{% translate 'Toggle dark mode' %}">
-        <svg id="theme-toggle-dark-icon" class="hidden h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
+        <svg id="theme-toggle-dark-icon" data-theme-toggle-icon="dark" class="hidden h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
           <path d="M17.293 13.293a8 8 0 11-10.586-10.586 8.001 8.001 0 1010.586 10.586z" />
         </svg>
-        <svg id="theme-toggle-light-icon" class="hidden h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
+        <svg id="theme-toggle-light-icon" data-theme-toggle-icon="light" class="hidden h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
           <path d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4.22 2.03a1 1 0 011.414 0l.708.707a1 1 0 11-1.414 1.415l-.708-.708a1 1 0 010-1.414zM17 9a1 1 0 100 2h1a1 1 0 100-2h-1zm-7 7a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zm-7-7a1 1 0 100 2H2a1 1 0 100-2h1zm1.636-5.657a1 1 0 011.414 0l.708.707A1 1 0 016.343 5.5l-.707-.708a1 1 0 010-1.414zM5.5 15.657a1 1 0 010 1.415l-.707.707a1 1 0 11-1.415-1.414l.708-.708a1 1 0 011.414 0zM15.657 14.5a1 1 0 011.414 0l.708.707a1 1 0 11-1.414 1.415l-.708-.708a1 1 0 010-1.414z" />
         </svg>
       </button>
@@ -175,31 +176,34 @@
 {% endblock %}
 
 {% block nav-sidebar %}
-<div id="sidebar-backdrop" class="fixed inset-0 z-30 hidden bg-gray-900/60 sm:hidden" aria-hidden="true"></div>
-<aside id="logo-sidebar" class="fixed left-0 top-0 z-40 flex h-screen w-64 -translate-x-full flex-col border-r border-gray-200 bg-white pt-20 shadow-lg transition-transform duration-300 ease-in-out dark:border-gray-700 dark:bg-gray-900 sm:translate-x-0" aria-label="{% translate 'Sidebar' %}">
+<div id="sidebar-backdrop" class="fixed inset-0 z-30 hidden bg-gray-900/60 sm:hidden" data-drawer-backdrop data-drawer-target="logo-sidebar" data-drawer-hide="logo-sidebar" aria-hidden="true"></div>
+<aside id="logo-sidebar" class="fixed left-0 top-0 z-40 flex h-screen w-64 -translate-x-full flex-col border-r border-gray-200 bg-white pt-20 shadow-lg transition-transform duration-300 ease-in-out dark:border-gray-700 dark:bg-gray-900 sm:translate-x-0" aria-label="{% translate 'Sidebar' %}" tabindex="-1">
   <div class="h-full overflow-y-auto px-4 pb-6">
     <div class="mb-6 hidden sm:block">
       <p class="px-3 text-[0.65rem] font-semibold uppercase tracking-[0.35em] text-gray-400 dark:text-gray-500">{% translate 'Navigation' %}</p>
     </div>
-    <ul class="list-none space-y-4 text-sm font-medium" data-sidebar-accordion>
+    <ul id="sidebar-accordion" class="list-none space-y-4 text-sm font-medium" data-accordion="collapse">
       {% with apps=app_list|default:available_apps %}
         {% if apps %}
           {% for app in apps %}
-            <li>
-              <button type="button" class="flex w-full items-center justify-between rounded-xl px-3 py-2 text-left text-[0.7rem] font-semibold uppercase tracking-[0.3em] text-gray-500 transition hover:bg-gray-100 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800/80 dark:hover:text-gray-200" data-sidebar-accordion-toggle aria-expanded="true" aria-controls="sidebar-app-{{ forloop.counter }}">
-                <span class="flex items-center gap-3">
-                  <span class="inline-flex h-8 w-8 items-center justify-center rounded-xl bg-gray-100 text-gray-500 dark:bg-gray-800 dark:text-gray-400">
-                    <svg class="h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
-                      <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 5.25h16.5M3.75 9.75h16.5m-16.5 4.5h16.5m-16.5 4.5h16.5" />
-                    </svg>
+            <li data-accordion-item>
+              <h3>
+                <button type="button" id="sidebar-app-heading-{{ forloop.counter }}" class="flex w-full items-center justify-between rounded-xl px-3 py-2 text-left text-[0.7rem] font-semibold uppercase tracking-[0.3em] text-gray-500 transition hover:bg-gray-100 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800/80 dark:hover:text-gray-200" data-accordion-target="#sidebar-app-panel-{{ forloop.counter }}" aria-expanded="false" aria-controls="sidebar-app-panel-{{ forloop.counter }}">
+                  <span class="flex items-center gap-3">
+                    <span class="inline-flex h-8 w-8 items-center justify-center rounded-xl bg-gray-100 text-gray-500 dark:bg-gray-800 dark:text-gray-400">
+                      <svg class="h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 5.25h16.5M3.75 9.75h16.5m-16.5 4.5h16.5m-16.5 4.5h16.5" />
+                      </svg>
+                    </span>
+                    <span class="text-xs tracking-[0.25em]">{{ app.name }}</span>
                   </span>
-                  <span class="text-xs tracking-[0.25em]">{{ app.name }}</span>
-                </span>
-                <svg class="h-4 w-4 text-gray-400 transition-transform duration-200" data-sidebar-accordion-arrow aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-                  <path stroke-linecap="round" stroke-linejoin="round" d="M6 9l6 6 6-6" />
-                </svg>
-              </button>
-              <ul id="sidebar-app-{{ forloop.counter }}" class="mt-3 list-none space-y-1 rounded-lg bg-gray-50/60 p-2 text-gray-600 dark:bg-gray-800/40 dark:text-gray-300" data-sidebar-accordion-panel>
+                  <svg class="h-4 w-4 text-gray-400 transition-transform duration-200" data-accordion-icon aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M6 9l6 6 6-6" />
+                  </svg>
+                </button>
+              </h3>
+              <div id="sidebar-app-panel-{{ forloop.counter }}" class="hidden" aria-labelledby="sidebar-app-heading-{{ forloop.counter }}">
+                <ul class="mt-3 list-none space-y-1 rounded-lg bg-gray-50/60 p-2 text-gray-600 dark:bg-gray-800/40 dark:text-gray-300">
                 {% for model in app.models %}
                   <li>
                     {% if model.admin_url %}
@@ -231,7 +235,8 @@
                     {% endif %}
                   </li>
                 {% endfor %}
-              </ul>
+                </ul>
+              </div>
             </li>
           {% endfor %}
         {% else %}
@@ -286,39 +291,4 @@
   {{ block.super }}
   <script src="{% static 'flowbite_admin/js/flowbite.min.js' %}"></script>
   <script src="{% static 'flowbite_admin/js/flowbite-admin.js' %}"></script>
-  <script>
-    (function () {
-      const themeToggleBtn = document.getElementById('theme-toggle');
-      if (!themeToggleBtn) {
-        return;
-      }
-      const darkIcon = document.getElementById('theme-toggle-dark-icon');
-      const lightIcon = document.getElementById('theme-toggle-light-icon');
-      function setIcons(isDark) {
-        if (isDark) {
-          darkIcon.classList.add('hidden');
-          lightIcon.classList.remove('hidden');
-        } else {
-          lightIcon.classList.add('hidden');
-          darkIcon.classList.remove('hidden');
-        }
-      }
-      const storedTheme = localStorage.getItem('color-theme');
-      const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-      const isDark = storedTheme === 'dark' || (!storedTheme && prefersDark);
-      setIcons(isDark);
-      themeToggleBtn.addEventListener('click', function () {
-        const isCurrentlyDark = document.documentElement.classList.contains('dark');
-        if (isCurrentlyDark) {
-          document.documentElement.classList.remove('dark');
-          localStorage.setItem('color-theme', 'light');
-          setIcons(false);
-        } else {
-          document.documentElement.classList.add('dark');
-          localStorage.setItem('color-theme', 'dark');
-          setIcons(true);
-        }
-      });
-    })();
-  </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- update the admin base template to use Flowbite drawer, accordion, dropdown, and theme toggle data attributes
- replace bespoke admin scripting with Flowbite-driven initialisers plus modular dark-mode and responsive helpers
- ship a lightweight Flowbite helper bundle and CSS tweaks so icons react to aria-expanded state

## Testing
- python -m compileall flowbite_admin

------
https://chatgpt.com/codex/tasks/task_e_68dc4d2343b08326b37cfa1af199f45a