### PR TITLE
Style admin topbar components

### DIFF
--- a/flowbite_admin/static/flowbite_admin/css/flowbite-admin.css
+++ b/flowbite_admin/static/flowbite_admin/css/flowbite-admin.css
@@ -58,6 +58,107 @@ img, video {
   height: auto;
 }
 
+/* Topbar component styles */
+.topbar-search {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  width: 100%;
+  max-width: 24rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: 9999px;
+  background-color: #f1f5f9;
+  border: 1px solid #e5e7eb;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+.topbar-search:focus-within {
+  border-color: #3b82f6;
+  box-shadow: 0 0 0 4px rgba(59, 130, 246, 0.1);
+}
+.topbar-search__input {
+  flex: 1 1 auto;
+  min-width: 0;
+  border: none;
+  background-color: transparent;
+  font-size: 0.875rem;
+  color: #1f2937;
+}
+.topbar-search__input::placeholder {
+  color: #9ca3af;
+}
+.topbar-icon-group {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+.topbar-icon-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 9999px;
+  border: 1px solid #e5e7eb;
+  background-color: #ffffff;
+  color: #6b7280;
+  transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+.topbar-icon-button:hover {
+  background-color: #f1f5f9;
+  border-color: #d1d5db;
+  color: #111827;
+}
+.topbar-avatar {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 9999px;
+  background: linear-gradient(135deg, #2563eb, #3b82f6);
+  color: #ffffff;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+.dark .topbar-search {
+  background-color: rgba(17, 24, 39, 0.6);
+  border-color: #374151;
+}
+.dark .topbar-search:focus-within {
+  border-color: #60a5fa;
+  box-shadow: 0 0 0 4px rgba(96, 165, 250, 0.15);
+}
+.dark .topbar-search__input {
+  color: #f9fafb;
+}
+.dark .topbar-search__input::placeholder {
+  color: #6b7280;
+}
+.dark .topbar-icon-button {
+  border-color: #374151;
+  background-color: rgba(55, 65, 81, 0.4);
+  color: #e5e7eb;
+}
+.dark .topbar-icon-button:hover {
+  background-color: rgba(75, 85, 99, 0.5);
+  border-color: #4b5563;
+  color: #f9fafb;
+}
+.dark .topbar-avatar {
+  background: linear-gradient(135deg, #1d4ed8, #1f2937);
+}
+
 /* Generated utility classes */
 :root { --fb-focus-ring-width: 2px; --fb-focus-ring-offset: 0; --fb-focus-ring-color: rgba(59, 130, 246, 0.45); --fb-focus-ring-offset-color: transparent; }
 .dark :focus { box-shadow: 0 0 0 var(--fb-focus-ring-width, 2px) var(--fb-focus-ring-color, rgba(59, 130, 246, 0.45)); }
@@ -291,5 +392,3 @@ img, video {
 .w-full { width: 100%; }
 .z-30 { z-index: 30; }
 .z-40 { z-index: 40; }
-[data-dropdown-toggle][aria-expanded="true"] [data-dropdown-arrow] { transform: rotate(180deg); }
-button[aria-expanded="true"] [data-accordion-icon] { transform: rotate(180deg); }

--- a/tools/build-css.js
+++ b/tools/build-css.js
@@ -78,6 +78,107 @@ img, video {
   max-width: 100%;
   height: auto;
 }
+
+/* Topbar component styles */
+.topbar-search {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  width: 100%;
+  max-width: 24rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: 9999px;
+  background-color: #f1f5f9;
+  border: 1px solid #e5e7eb;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+.topbar-search:focus-within {
+  border-color: #3b82f6;
+  box-shadow: 0 0 0 4px rgba(59, 130, 246, 0.1);
+}
+.topbar-search__input {
+  flex: 1 1 auto;
+  min-width: 0;
+  border: none;
+  background-color: transparent;
+  font-size: 0.875rem;
+  color: #1f2937;
+}
+.topbar-search__input::placeholder {
+  color: #9ca3af;
+}
+.topbar-icon-group {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+.topbar-icon-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 9999px;
+  border: 1px solid #e5e7eb;
+  background-color: #ffffff;
+  color: #6b7280;
+  transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+.topbar-icon-button:hover {
+  background-color: #f1f5f9;
+  border-color: #d1d5db;
+  color: #111827;
+}
+.topbar-avatar {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 9999px;
+  background: linear-gradient(135deg, #2563eb, #3b82f6);
+  color: #ffffff;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+.dark .topbar-search {
+  background-color: rgba(17, 24, 39, 0.6);
+  border-color: #374151;
+}
+.dark .topbar-search:focus-within {
+  border-color: #60a5fa;
+  box-shadow: 0 0 0 4px rgba(96, 165, 250, 0.15);
+}
+.dark .topbar-search__input {
+  color: #f9fafb;
+}
+.dark .topbar-search__input::placeholder {
+  color: #6b7280;
+}
+.dark .topbar-icon-button {
+  border-color: #374151;
+  background-color: rgba(55, 65, 81, 0.4);
+  color: #e5e7eb;
+}
+.dark .topbar-icon-button:hover {
+  background-color: rgba(75, 85, 99, 0.5);
+  border-color: #4b5563;
+  color: #f9fafb;
+}
+.dark .topbar-avatar {
+  background: linear-gradient(135deg, #1d4ed8, #1f2937);
+}
 `;
 
 const colorMap = {


### PR DESCRIPTION
## Summary
- add Flowbite-inspired topbar component rules to the Tailwind build configuration
- regenerate the distributed CSS bundle with search, icon, avatar, and sr-only styles

## Testing
- npm run build
- DJANGO_SETTINGS_MODULE=tests.settings python -m django test

------
https://chatgpt.com/codex/tasks/task_e_68dc551a074483268c7605d32c157a00