### PR TITLE
Style admin fieldsets with Flowbite cards

### DIFF
--- a/flowbite_admin/templates/admin/includes/fieldset.html
+++ b/flowbite_admin/templates/admin/includes/fieldset.html
@@ -1,0 +1,52 @@
+{% load i18n %}
+{% with heading_tag=heading_level|default:2 %}
+<section
+  class="space-y-6 {{ fieldset.classes|default:'' }}"
+  {% if fieldset.name %}aria-labelledby="{{ prefix }}-{{ id_prefix }}-{{ id_suffix }}-heading"{% endif %}
+>
+  {% if fieldset.name %}
+    {% if fieldset.is_collapsible %}
+      <details class="group space-y-5" data-admin-fieldset{% if 'collapsed' not in fieldset.classes|default:'' %} open{% endif %}>
+        <summary class="flex cursor-pointer items-center justify-between gap-3 text-left">
+          <h{{ heading_tag }}
+            id="{{ prefix }}-{{ id_prefix }}-{{ id_suffix }}-heading"
+            class="text-lg font-semibold text-gray-900 transition-colors duration-150 group-open:text-blue-700 dark:text-white dark:group-open:text-blue-300"
+          >
+            {{ fieldset.name }}
+          </h{{ heading_tag }}>
+          <span class="text-sm font-medium text-gray-500 group-open:hidden dark:text-gray-400">{% translate "Show" %}</span>
+          <span class="hidden text-sm font-medium text-gray-500 group-open:inline dark:text-gray-400">{% translate "Hide" %}</span>
+        </summary>
+        {% if fieldset.description %}
+          <p class="text-sm text-gray-500 dark:text-gray-400">{{ fieldset.description|safe }}</p>
+        {% endif %}
+        <div class="space-y-6">
+          {% include "admin/includes/fieldset_line.html" %}
+        </div>
+      </details>
+    {% else %}
+      <header class="space-y-2">
+        <h{{ heading_tag }}
+          id="{{ prefix }}-{{ id_prefix }}-{{ id_suffix }}-heading"
+          class="text-lg font-semibold text-gray-900 dark:text-white"
+        >
+          {{ fieldset.name }}
+        </h{{ heading_tag }}>
+        {% if fieldset.description %}
+          <p class="text-sm text-gray-500 dark:text-gray-400">{{ fieldset.description|safe }}</p>
+        {% endif %}
+      </header>
+      <div class="space-y-6">
+        {% include "admin/includes/fieldset_line.html" %}
+      </div>
+    {% endif %}
+  {% else %}
+    {% if fieldset.description %}
+      <p class="text-sm text-gray-500 dark:text-gray-400">{{ fieldset.description|safe }}</p>
+    {% endif %}
+    <div class="space-y-6">
+      {% include "admin/includes/fieldset_line.html" %}
+    </div>
+  {% endif %}
+</section>
+{% endwith %}

--- a/flowbite_admin/templates/admin/includes/fieldset_line.html
+++ b/flowbite_admin/templates/admin/includes/fieldset_line.html
@@ -1,0 +1,60 @@
+{% for line in fieldset %}
+  {% with is_single=line.fields|length == 1 %}
+    <div class="space-y-3{% if not line.has_visible_field %} hidden{% endif %}">
+      {% if is_single and line.errors %}
+        <div class="rounded-lg border border-red-200 bg-red-50 p-3 text-sm font-medium text-red-700 dark:border-red-900/50 dark:bg-red-900/30 dark:text-red-200">
+          {{ line.errors }}
+        </div>
+      {% endif %}
+      <div class="{% if is_single %}space-y-3{% else %}flex flex-col gap-6 lg:flex-row lg:flex-wrap{% endif %}">
+        {% for field in line %}
+          {% if field.field.is_hidden %}
+            {{ field.field }}
+          {% else %}
+            <div class="min-w-0 space-y-2{% if not is_single %} lg:min-w-[16rem] lg:flex-1{% endif %}">
+              {% if not is_single and not field.is_readonly and field.errors %}
+                <div class="rounded-lg border border-red-200 bg-red-50 p-3 text-sm font-medium text-red-700 dark:border-red-900/50 dark:bg-red-900/30 dark:text-red-200">
+                  {{ field.errors }}
+                </div>
+              {% endif %}
+              <div class="space-y-2">
+                {% if field.is_checkbox %}
+                  <label class="flex items-start gap-3 rounded-lg border border-gray-200 bg-gray-50 px-4 py-3 text-sm text-gray-700 dark:border-gray-700 dark:bg-gray-800/60 dark:text-gray-200">
+                    {{ field.field }}
+                    <span class="font-medium text-gray-900 dark:text-gray-100">
+                      {{ field.field.label|default_if_none:"" }}{% if field.field.field.required %}<span class="text-red-600 dark:text-red-300">*</span>{% endif %}
+                    </span>
+                  </label>
+                {% else %}
+                  <div class="space-y-1">
+                    {% if field.field.id_for_label %}
+                      <label for="{{ field.field.id_for_label }}" class="block text-sm font-medium text-gray-900 dark:text-gray-100">
+                        {{ field.field.label|default_if_none:"" }}{% if field.field.field.required %}<span class="text-red-600 dark:text-red-300">*</span>{% endif %}:
+                      </label>
+                    {% else %}
+                      <span class="block text-sm font-medium text-gray-900 dark:text-gray-100">
+                        {{ field.field.label|default_if_none:"" }}{% if field.field.field.required %}<span class="text-red-600 dark:text-red-300">*</span>{% endif %}:
+                      </span>
+                    {% endif %}
+                    {% if field.is_readonly %}
+                      <div class="rounded-lg border border-gray-200 bg-gray-50 px-4 py-2 text-sm text-gray-700 dark:border-gray-700 dark:bg-gray-800/60 dark:text-gray-200">
+                        {{ field.contents }}
+                      </div>
+                    {% else %}
+                      {{ field.field }}
+                    {% endif %}
+                  </div>
+                {% endif %}
+              </div>
+              {% if field.field.help_text %}
+                <p class="text-sm text-gray-500 dark:text-gray-400"{% if field.field.id_for_label %} id="{{ field.field.id_for_label }}_helptext"{% endif %}>
+                  {{ field.field.help_text|safe }}
+                </p>
+              {% endif %}
+            </div>
+          {% endif %}
+        {% endfor %}
+      </div>
+    </div>
+  {% endwith %}
+{% endfor %}


### PR DESCRIPTION
## Summary
- replace the default Django fieldset template with a Flowbite-inspired card layout
- extract line rendering into a helper include that applies Tailwind classes to labels, help text, and inline errors
- support collapsible sections with accessible headings and translated show/hide cues

## Testing
- python -m compileall flowbite_admin

------
https://chatgpt.com/codex/tasks/task_e_68dfc21ddb34832683515da05a525f7d