### PR TITLE
Adjust ProjectAdminSite.get_app_list signature

### DIFF
--- a/tests/admin.py
+++ b/tests/admin.py
@@ -3,8 +3,32 @@ from django.contrib import admin
 from .models import Book
 
 
+class ProjectAdminSite(admin.AdminSite):
+    """Custom admin site used by the test project."""
+
+    site_header = "Flowbite Admin"
+    site_title = "Flowbite Admin"
+    index_title = "Project administration"
+
+    def get_app_list(self, request, app_label=None):  # type: ignore[override]
+        """Return the list of installed apps for the index dashboard."""
+
+        app_list = super().get_app_list(request, app_label)
+
+        if app_label is not None:
+            return app_list
+
+        return sorted(app_list, key=lambda app: app["name"].lower())
+
+
+project_admin_site = ProjectAdminSite(name="project_admin")
+
+
 @admin.register(Book)
 class BookAdmin(admin.ModelAdmin):
     list_display = ("title", "author", "published")
     search_fields = ("title", "author")
     list_filter = ("published",)
+
+
+project_admin_site.register(Book, BookAdmin)


### PR DESCRIPTION
## Summary
- add a custom `ProjectAdminSite` for the test project with branded titles
- update `ProjectAdminSite.get_app_list` to accept the optional `app_label` argument, forwarding it to Django's implementation and applying ordering only when the full list is requested
- register the `Book` admin with the project admin site so it mirrors the default site registrations

## Testing
- DJANGO_SETTINGS_MODULE=tests.settings python -m django test

------
https://chatgpt.com/codex/tasks/task_e_68dfcf0294048326b42448c7538cd90c