### PR TITLE
Handle optional admin app label when ordering app list

### DIFF
--- a/tests/admin.py
+++ b/tests/admin.py
@@ -16,9 +16,12 @@ class ProjectAdminSite(admin.AdminSite):
         app_list = super().get_app_list(request, app_label)
 
         if app_label is not None:
+            # When Django asks for a single app index, return the list untouched so
+            # the framework can render the requested page without hitting our
+            # custom ordering logic below.
             return app_list
 
-        return sorted(app_list, key=lambda app: app["name"].lower())
+        return sorted(app_list, key=lambda app: app["name"].casefold())
 
 
 project_admin_site = ProjectAdminSite(name="project_admin")


### PR DESCRIPTION
## Summary
- ensure the custom admin site defers to Django's default app list when an app label is requested
- keep the alphabetical ordering for the index view using a case-insensitive sort and document the behavior

## Testing
- not run (Django settings module not configured for pytest in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e0c36599c88326b393b6fcaffa0eda