### PR TITLE
Add branded sidebar header

### DIFF
--- a/flowbite_admin/static/flowbite_admin/css/flowbite-admin.css
+++ b/flowbite_admin/static/flowbite_admin/css/flowbite-admin.css
@@ -304,6 +304,7 @@ img, video {
 .gap-6 { gap: 1.5rem; }
 .grid { display: grid; }
 .group-hover\:text-blue-600 { color: #2563eb; }
+.h-10 { height: 2.5rem; }
 .h-4 { height: 1rem; }
 .h-5 { height: 1.25rem; }
 .h-8 { height: 2rem; }
@@ -430,6 +431,7 @@ img, video {
 .transition { transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1); }
 .transition-transform { transition-property: transform; transition-duration: 0.2s; transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1); }
 .uppercase { text-transform: uppercase; }
+.w-10 { width: 2.5rem; }
 .w-4 { width: 1rem; }
 .w-5 { width: 1.25rem; }
 .w-64 { width: 16rem; }

--- a/flowbite_admin/static/flowbite_admin/images/logo-icon.svg
+++ b/flowbite_admin/static/flowbite_admin/images/logo-icon.svg
@@ -1,0 +1,11 @@
+<svg width="40" height="40" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="flowbite-admin-logo-gradient" x1="6" y1="6" x2="34" y2="34" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#1D4ED8" />
+      <stop offset="1" stop-color="#3B82F6" />
+    </linearGradient>
+  </defs>
+  <rect x="2" y="2" width="36" height="36" rx="18" fill="url(#flowbite-admin-logo-gradient)" />
+  <path d="M14.5 20C14.5 16.9624 16.9624 14.5 20 14.5C23.0376 14.5 25.5 16.9624 25.5 20C25.5 23.0376 23.0376 25.5 20 25.5H17.25" stroke="white" stroke-width="2.25" stroke-linecap="round" stroke-linejoin="round" />
+  <path d="M18.5 14.5L25.5 14.5L25.5 21.5" stroke="white" stroke-width="2.25" stroke-linecap="round" stroke-linejoin="round" />
+</svg>

--- a/flowbite_admin/templates/admin/base_site.html
+++ b/flowbite_admin/templates/admin/base_site.html
@@ -178,11 +178,18 @@
 {% block nav-sidebar %}
 <div id="sidebar-backdrop" class="fixed inset-0 z-30 hidden bg-gray-900/60 sm:hidden" data-drawer-backdrop data-drawer-target="logo-sidebar" data-drawer-hide="logo-sidebar" aria-hidden="true"></div>
 <aside id="logo-sidebar" class="fixed left-0 top-0 z-40 flex h-screen w-64 -translate-x-full flex-col border-r border-gray-200 bg-white pt-20 shadow-lg transition-transform duration-300 ease-in-out dark:border-gray-700 dark:bg-gray-900 sm:translate-x-0" aria-label="{% translate 'Sidebar' %}" tabindex="-1">
-  <div class="h-full overflow-y-auto px-4 pb-6">
-    <div class="mb-6 hidden sm:block">
-      <p class="px-3 text-[0.65rem] font-semibold uppercase tracking-[0.35em] text-gray-400 dark:text-gray-500">{% translate 'Navigation' %}</p>
+  <div class="flex h-full flex-col">
+    <div class="sticky top-20 z-10 border-b border-gray-200 bg-white px-4 pb-4 dark:border-gray-700 dark:bg-gray-900">
+      <a href="{% url 'admin:index' %}" class="flex w-full items-center gap-3 rounded-xl px-3 py-2 text-base font-semibold text-gray-900 transition-colors duration-150 hover:bg-gray-100 dark:text-white dark:hover:bg-gray-800">
+        <img src="{% static 'flowbite_admin/images/logo-icon.svg' %}" alt="" class="h-10 w-10 flex-shrink-0" />
+        <span class="truncate">{% firstof site_header site_title _('Flowbite Admin') %}</span>
+      </a>
     </div>
-    <ul id="sidebar-accordion" class="list-none space-y-4 text-sm font-medium" data-accordion="collapse">
+    <div class="flex-1 overflow-y-auto px-4 pb-6 pt-6">
+      <div class="mb-6 hidden sm:block">
+        <p class="px-3 text-[0.65rem] font-semibold uppercase tracking-[0.35em] text-gray-400 dark:text-gray-500">{% translate 'Navigation' %}</p>
+      </div>
+      <ul id="sidebar-accordion" class="list-none space-y-4 text-sm font-medium" data-accordion="collapse">
       <li class="list-none">
         <a href="{% url 'admin:index' %}"
           class="group flex items-center gap-3 rounded-xl bg-white/0 px-3 py-2 text-gray-600 transition-colors duration-150 hover:bg-white hover:text-gray-900 dark:text-gray-300 dark:hover:bg-gray-800 dark:hover:text-white">
@@ -265,6 +272,7 @@
         {% endif %}
       {% endwith %}
     </ul>
+    </div>
   </div>
 </aside>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add a sticky Flowbite-style brand row to the admin sidebar that links back to the dashboard
- add a packaged logo icon asset and load it via Django static files
- rebuild the Tailwind bundle so the new sizing utilities are available

## Testing
- npm run build:css
- Manually verified the sidebar header on desktop and mobile layouts

------
https://chatgpt.com/codex/tasks/task_e_68e0ce8d34648326887503707cf91bc6