### PR TITLE
Update admin sidebar to Flowbite pattern

### DIFF
--- a/flowbite_admin/static/flowbite_admin/css/flowbite-admin.css
+++ b/flowbite_admin/static/flowbite_admin/css/flowbite-admin.css
@@ -63,6 +63,14 @@ img, video {
   list-style: none;
 }
 
+#sidebar-accordion [data-accordion-icon] {
+  transition: transform 0.2s ease;
+}
+
+[data-accordion-item] > h3 > button[aria-expanded="true"] [data-accordion-icon] {
+  transform: rotate(180deg);
+}
+
 /* Topbar component styles */
 .topbar-search {
   display: flex;
@@ -195,7 +203,6 @@ img, video {
 .bg-gray-100 { background-color: #f1f5f9; }
 .bg-gray-200 { background-color: #e5e7eb; }
 .bg-gray-50 { background-color: #f9fafb; }
-.bg-gray-50\/60 { background-color: rgba(249, 250, 251, 0.6); }
 .bg-gray-900\/60 { background-color: rgba(17, 24, 39, 0.6); }
 .bg-green-50 { background-color: #ecfdf5; }
 .bg-red-50 { background-color: #fef2f2; }
@@ -224,7 +231,6 @@ img, video {
 .dark .dark\:bg-gray-600\/60 { background-color: rgba(75, 85, 99, 0.6); }
 .dark .dark\:bg-gray-700 { background-color: #374151; }
 .dark .dark\:bg-gray-800 { background-color: #1f2937; }
-.dark .dark\:bg-gray-800\/40 { background-color: rgba(31, 41, 55, 0.4); }
 .dark .dark\:bg-gray-800\/50 { background-color: rgba(31, 41, 55, 0.5); }
 .dark .dark\:bg-gray-900 { background-color: #111827; }
 .dark .dark\:bg-gray-900\/40 { background-color: rgba(17, 24, 39, 0.4); }
@@ -241,21 +247,17 @@ img, video {
 .dark\:focus\:ring-offset-gray-900:focus { outline: none; box-shadow: 0 0 0 var(--fb-focus-ring-offset, 0) var(--fb-focus-ring-offset-color, transparent), 0 0 0 calc(var(--fb-focus-ring-width, 2px) + var(--fb-focus-ring-offset, 0)) var(--fb-focus-ring-color, rgba(59, 130, 246, 0.45)); }
 .dark .dark\:focus\:ring-offset-red-900 { --fb-focus-ring-offset-color: rgba(127, 29, 29, 1); }
 .dark\:focus\:ring-offset-red-900:focus { outline: none; box-shadow: 0 0 0 var(--fb-focus-ring-offset, 0) var(--fb-focus-ring-offset-color, transparent), 0 0 0 calc(var(--fb-focus-ring-width, 2px) + var(--fb-focus-ring-offset, 0)) var(--fb-focus-ring-color, rgba(59, 130, 246, 0.45)); }
-.dark .dark\:group-hover\:bg-blue-900\/30 { background-color: rgba(30, 58, 138, 0.3); }
-.dark .dark\:group-hover\:bg-blue-900\/40 { background-color: rgba(30, 58, 138, 0.4); }
-.dark .dark\:group-hover\:text-blue-300 { color: #93c5fd; }
 .dark .dark\:hover\:\[\&_tr\]\:bg-gray-700\/60:hover { background-color: rgba(55, 65, 81, 0.6); }
+.dark .dark\:hover\:bg-blue-900\/40:hover { background-color: rgba(30, 58, 138, 0.4); }
 .dark .dark\:hover\:bg-gray-600\/60:hover { background-color: rgba(75, 85, 99, 0.6); }
 .dark .dark\:hover\:bg-gray-700:hover { background-color: #374151; }
 .dark .dark\:hover\:bg-gray-700\/70:hover { background-color: rgba(55, 65, 81, 0.7); }
 .dark .dark\:hover\:bg-gray-800:hover { background-color: #1f2937; }
-.dark .dark\:hover\:bg-gray-800\/80:hover { background-color: rgba(31, 41, 55, 0.8); }
 .dark .dark\:hover\:bg-red-900\/40:hover { background-color: rgba(127, 29, 29, 0.4); }
 .dark .dark\:hover\:bg-yellow-300:hover { background-color: #fcd34d; }
 .dark .dark\:hover\:text-blue-300:hover { color: #93c5fd; }
 .dark .dark\:hover\:text-blue-400:hover { color: #60a5fa; }
 .dark .dark\:hover\:text-gray-100:hover { color: #f1f5f9; }
-.dark .dark\:hover\:text-gray-200:hover { color: #e5e7eb; }
 .dark .dark\:hover\:text-red-200:hover { color: #fecaca; }
 .dark .dark\:hover\:text-white:hover { color: #ffffff; }
 .dark .dark\:ring-gray-700 { box-shadow: 0 0 0 1px #374151; --fb-focus-ring-color: rgba(55, 65, 81, 0.45); }
@@ -273,6 +275,9 @@ img, video {
 .dark .dark\:text-red-200 { color: #fecaca; }
 .dark .dark\:text-white { color: #ffffff; }
 .dark .dark\:text-yellow-200 { color: #fde68a; }
+.duration-200 { transition-duration: 0.2s; }
+.duration-300 { transition-duration: 0.3s; }
+.ease-in-out { transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1); }
 .fixed { position: fixed; }
 .flex { display: flex; }
 .flex-1 { flex: 1 1 0%; }
@@ -303,22 +308,22 @@ img, video {
 .gap-4 { gap: 1rem; }
 .gap-6 { gap: 1.5rem; }
 .grid { display: grid; }
-.group-hover\:text-blue-600 { color: #2563eb; }
 .h-10 { height: 2.5rem; }
 .h-4 { height: 1rem; }
 .h-5 { height: 1.25rem; }
+.h-6 { height: 1.5rem; }
 .h-8 { height: 2rem; }
 .h-full { height: 100%; }
 .h-screen { height: 100vh; }
 .hidden { display: none; }
 .hover\:\[\&_tr\]\:bg-gray-50:hover { background-color: #f9fafb; }
+.hover\:bg-blue-100:hover { background-color: #dbeafe; }
 .hover\:bg-blue-50:hover { background-color: #eff6ff; }
 .hover\:bg-blue-700:hover { background-color: #1d4ed8; }
 .hover\:bg-gray-100:hover { background-color: #f1f5f9; }
 .hover\:bg-gray-200:hover { background-color: #e5e7eb; }
 .hover\:bg-red-50:hover { background-color: #fef2f2; }
 .hover\:bg-red-700:hover { background-color: #b91c1c; }
-.hover\:bg-white:hover { background-color: #ffffff; }
 .hover\:text-blue-500:hover { color: #3b82f6; }
 .hover\:text-blue-600:hover { color: #2563eb; }
 .hover\:text-blue-700:hover { color: #1d4ed8; }
@@ -349,6 +354,8 @@ img, video {
 @media (min-width: 768px) { .md\:justify-between { justify-content: space-between; } }
 @media (min-width: 768px) { .md\:w-1\/2 { width: 50%; } }
 .min-h-\[70vh\] { min-height: 70vh; }
+.ml-3 { margin-left: 0.75rem; }
+.ml-auto { margin-left: auto; }
 .mt-1 { margin-top: 0.25rem; }
 .mt-2 { margin-top: 0.5rem; }
 .mt-20 { margin-top: 5rem; }
@@ -362,18 +369,22 @@ img, video {
 .overflow-hidden { overflow: hidden; }
 .overflow-x-auto { overflow-x: auto; }
 .overflow-y-auto { overflow-y: auto; }
+.p-1 { padding: 0.25rem; }
 .p-2 { padding: 0.5rem; }
 .p-3 { padding: 0.75rem; }
 .p-4 { padding: 1rem; }
 .p-6 { padding: 1.5rem; }
 .p-8 { padding: 2rem; }
 .pb-6 { padding-bottom: 1.5rem; }
+.pl-2 { padding-left: 0.5rem; }
 .pl-6 { padding-left: 1.5rem; }
 .placeholder\:text-gray-400 { color: #9ca3af; }
 .pt-20 { padding-top: 5rem; }
+.px-2 { padding-left: 0.5rem; padding-right: 0.5rem; }
 .px-3 { padding-left: 0.75rem; padding-right: 0.75rem; }
 .px-4 { padding-left: 1rem; padding-right: 1rem; }
 .px-6 { padding-left: 1.5rem; padding-right: 1.5rem; }
+.py-0\.5 { padding-top: 0.125rem; padding-bottom: 0.125rem; }
 .py-1 { padding-top: 0.25rem; padding-bottom: 0.25rem; }
 .py-2 { padding-top: 0.5rem; padding-bottom: 0.5rem; }
 .py-3 { padding-top: 0.75rem; padding-bottom: 0.75rem; }
@@ -416,6 +427,7 @@ img, video {
 .text-gray-800 { color: #1f2937; }
 .text-gray-900 { color: #111827; }
 .text-green-800 { color: #065f46; }
+.text-left { text-align: left; }
 .text-lg { font-size: 1.125rem; line-height: 1.75rem; }
 .text-red-600 { color: #dc2626; }
 .text-red-700 { color: #b91c1c; }
@@ -429,11 +441,14 @@ img, video {
 .top-0 { top: 0; }
 .tracking-wide { letter-spacing: 0.05em; }
 .transition { transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1); }
+.transition-colors { transition-property: color, background-color, border-color; transition-duration: 0.2s; transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1); }
 .transition-transform { transition-property: transform; transition-duration: 0.2s; transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1); }
+.truncate { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .uppercase { text-transform: uppercase; }
 .w-10 { width: 2.5rem; }
 .w-4 { width: 1rem; }
 .w-5 { width: 1.25rem; }
+.w-6 { width: 1.5rem; }
 .w-64 { width: 16rem; }
 .w-auto { width: auto; }
 .w-full { width: 100%; }

--- a/flowbite_admin/templates/admin/base_site.html
+++ b/flowbite_admin/templates/admin/base_site.html
@@ -192,23 +192,12 @@
       <ul id="sidebar-accordion" class="list-none space-y-4 text-sm font-medium" data-accordion="collapse">
       <li class="list-none">
         <a href="{% url 'admin:index' %}"
-          class="group flex items-center gap-3 rounded-xl bg-white/0 px-3 py-2 text-gray-600 transition-colors duration-150 hover:bg-white hover:text-gray-900 dark:text-gray-300 dark:hover:bg-gray-800 dark:hover:text-white">
-          <span
-            class="inline-flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg bg-white text-gray-500 shadow-sm transition-colors duration-150 group-hover:bg-blue-100 group-hover:text-blue-600 dark:bg-gray-900 dark:text-gray-400 dark:group-hover:bg-blue-900/30 dark:group-hover:text-blue-300">
-            <svg class="h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"
-              aria-hidden="true">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 4.5h16.5M3.75 9.75h16.5m-11.25 5.25H21m-17.25 0H9m-5.25 4.5H15" />
-            </svg>
-          </span>
-          <span class="flex-1 truncate text-sm font-medium">{% translate 'Dashboard' %}</span>
-          <span
-            class="inline-flex items-center rounded-lg bg-blue-50 px-2 py-0.5 text-[0.65rem] font-semibold uppercase tracking-wide text-blue-600 transition-colors duration-150 group-hover:bg-blue-100 dark:bg-blue-900/30 dark:text-blue-300 dark:group-hover:bg-blue-900/40">
-            <svg class="h-3 w-3" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"
-              aria-hidden="true">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M13.5 4.5L21 12l-7.5 7.5M3 12h18" />
-            </svg>
-            <span class="sr-only">{% translate 'Go to dashboard' %}</span>
-          </span>
+          class="flex items-center gap-3 rounded-lg p-2 text-sm font-medium text-gray-700 transition hover:bg-gray-100 hover:text-gray-900 dark:text-gray-200 dark:hover:bg-gray-700 dark:hover:text-white">
+          <svg class="h-6 w-6 shrink-0 text-gray-500 dark:text-gray-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"
+            aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 4.5h16.5M3.75 9.75h16.5m-11.25 5.25H21m-17.25 0H9m-5.25 4.5H15" />
+          </svg>
+          <span class="ml-3 flex-1 truncate">{% translate 'Dashboard' %}</span>
         </a>
       </li>
       {% with apps=app_list|default:available_apps %}
@@ -216,34 +205,28 @@
           {% for app in apps %}
             <li class="list-none" data-accordion-item>
               <h3>
-                <button type="button" id="sidebar-app-heading-{{ forloop.counter }}" class="flex w-full items-center justify-between rounded-xl px-3 py-2 text-left text-[0.7rem] font-semibold uppercase tracking-[0.3em] text-gray-500 transition hover:bg-gray-100 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800/80 dark:hover:text-gray-200" data-accordion-target="#sidebar-app-panel-{{ forloop.counter }}" aria-expanded="false" aria-controls="sidebar-app-panel-{{ forloop.counter }}">
-                  <span class="flex items-center gap-3">
-                    <span class="inline-flex h-8 w-8 items-center justify-center rounded-xl bg-gray-100 text-gray-500 dark:bg-gray-800 dark:text-gray-400">
-                      <svg class="h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
-                        <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 5.25h16.5M3.75 9.75h16.5m-16.5 4.5h16.5m-16.5 4.5h16.5" />
-                      </svg>
-                    </span>
-                    <span class="text-xs tracking-[0.25em]">{{ app.name }}</span>
-                  </span>
-                  <svg class="h-4 w-4 text-gray-400 transition-transform duration-200" data-accordion-icon aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                <button type="button" id="sidebar-app-heading-{{ forloop.counter }}" class="flex w-full items-center rounded-lg p-2 text-left text-sm font-medium text-gray-600 transition hover:bg-gray-100 hover:text-gray-900 dark:text-gray-200 dark:hover:bg-gray-700 dark:hover:text-white" data-accordion-target="#sidebar-app-panel-{{ forloop.counter }}" aria-expanded="false" aria-controls="sidebar-app-panel-{{ forloop.counter }}">
+                  <svg class="h-6 w-6 shrink-0 text-gray-500 dark:text-gray-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 5.25h16.5M3.75 9.75h16.5m-16.5 4.5h16.5m-16.5 4.5h16.5" />
+                  </svg>
+                  <span class="ml-3 flex-1 text-left">{{ app.name }}</span>
+                  <svg class="ml-auto h-4 w-4 shrink-0 text-gray-400 transition-transform duration-200" data-accordion-icon aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
                     <path stroke-linecap="round" stroke-linejoin="round" d="M6 9l6 6 6-6" />
                   </svg>
                 </button>
               </h3>
               <div id="sidebar-app-panel-{{ forloop.counter }}" class="hidden" aria-labelledby="sidebar-app-heading-{{ forloop.counter }}">
-                <ul class="mt-3 list-none space-y-1 rounded-lg bg-gray-50/60 p-2 text-gray-600 dark:bg-gray-800/40 dark:text-gray-300">
+                <ul class="mt-1 list-none space-y-1 pl-2">
                 {% for model in app.models %}
                   <li class="list-none">
                     {% if model.admin_url %}
-                      <a href="{{ model.admin_url }}" class="group flex items-center gap-3 rounded-lg px-3 py-2 transition-colors duration-150 hover:bg-white hover:text-gray-900 dark:hover:bg-gray-800 dark:hover:text-white">
-                        <span class="inline-flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg bg-white text-gray-500 shadow-sm transition-colors duration-150 group-hover:bg-blue-100 group-hover:text-blue-600 dark:bg-gray-900 dark:text-gray-400 dark:group-hover:bg-blue-900/30 dark:group-hover:text-blue-300">
-                          <svg class="h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
-                            <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 6.75h15M4.5 12h15m-15 5.25h15" />
-                          </svg>
-                        </span>
-                        <span class="flex-1 truncate text-sm font-medium">{{ model.name }}</span>
+                      <a href="{{ model.admin_url }}" class="flex items-center gap-3 rounded-lg p-2 text-sm font-medium text-gray-600 transition hover:bg-gray-100 hover:text-gray-900 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white">
+                        <svg class="h-5 w-5 shrink-0 text-gray-500 dark:text-gray-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+                          <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 6.75h15M4.5 12h15m-15 5.25h15" />
+                        </svg>
+                        <span class="flex-1 truncate">{{ model.name }}</span>
                         {% if model.add_url %}
-                          <span class="inline-flex items-center rounded-lg bg-blue-50 px-2 py-0.5 text-[0.65rem] font-semibold uppercase tracking-wide text-blue-600 transition-colors duration-150 group-hover:bg-blue-100 dark:bg-blue-900/30 dark:text-blue-300 dark:group-hover:bg-blue-900/40" title="{% translate 'Add' %}">
+                          <span class="inline-flex items-center rounded-lg bg-blue-50 px-2 py-0.5 text-[0.65rem] font-semibold uppercase tracking-wide text-blue-600 transition hover:bg-blue-100 dark:bg-blue-900/30 dark:text-blue-300 dark:hover:bg-blue-900/40" title="{% translate 'Add' %}">
                             <svg class="h-3 w-3" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" aria-hidden="true">
                               <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
                             </svg>
@@ -252,13 +235,11 @@
                         {% endif %}
                       </a>
                     {% else %}
-                      <span class="flex items-center gap-3 rounded-lg px-3 py-2 text-gray-400 dark:text-gray-500">
-                        <span class="inline-flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg bg-white text-gray-400 shadow-sm dark:bg-gray-900 dark:text-gray-600">
-                          <svg class="h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
-                            <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 6.75h15M4.5 12h15m-15 5.25h15" />
-                          </svg>
-                        </span>
-                        <span class="flex-1 truncate text-sm font-medium">{{ model.name }}</span>
+                      <span class="flex items-center gap-3 rounded-lg p-2 text-sm font-medium text-gray-400 dark:text-gray-500">
+                        <svg class="h-5 w-5 shrink-0 text-gray-400 dark:text-gray-600" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+                          <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 6.75h15M4.5 12h15m-15 5.25h15" />
+                        </svg>
+                        <span class="flex-1 truncate">{{ model.name }}</span>
                       </span>
                     {% endif %}
                   </li>

--- a/tools/build-css.js
+++ b/tools/build-css.js
@@ -84,6 +84,14 @@ img, video {
   list-style: none;
 }
 
+#sidebar-accordion [data-accordion-icon] {
+  transition: transform 0.2s ease;
+}
+
+[data-accordion-item] > h3 > button[aria-expanded="true"] [data-accordion-icon] {
+  transform: rotate(180deg);
+}
+
 /* Topbar component styles */
 .topbar-search {
   display: flex;
@@ -209,6 +217,7 @@ img, video {
 const colorMap = {
   white: '#ffffff',
   'blue-50': '#eff6ff',
+  'blue-100': '#dbeafe',
   'blue-500': '#3b82f6',
   'blue-600': '#2563eb',
   'blue-700': '#1d4ed8',
@@ -269,6 +278,7 @@ const spacingScale = {
   '6': '1.5rem',
   '8': '2rem',
   '10': '2.5rem',
+  '11': '2.75rem',
   '12': '3rem',
   '16': '4rem',
   '20': '5rem',
@@ -378,20 +388,26 @@ function baseDeclaration(base) {
     case 'gap-4': return 'gap: 1rem;';
     case 'gap-6': return 'gap: 1.5rem;';
     case 'gap-8': return 'gap: 2rem;';
+    case 'p-1': return 'padding: 0.25rem;';
     case 'p-2': return 'padding: 0.5rem;';
     case 'p-3': return 'padding: 0.75rem;';
     case 'p-4': return 'padding: 1rem;';
     case 'p-6': return 'padding: 1.5rem;';
     case 'p-8': return 'padding: 2rem;';
+    case 'px-2': return 'padding-left: 0.5rem; padding-right: 0.5rem;';
     case 'px-3': return 'padding-left: 0.75rem; padding-right: 0.75rem;';
     case 'px-4': return 'padding-left: 1rem; padding-right: 1rem;';
     case 'px-6': return 'padding-left: 1.5rem; padding-right: 1.5rem;';
+    case 'py-0.5': return 'padding-top: 0.125rem; padding-bottom: 0.125rem;';
     case 'py-1': return 'padding-top: 0.25rem; padding-bottom: 0.25rem;';
     case 'py-2': return 'padding-top: 0.5rem; padding-bottom: 0.5rem;';
     case 'py-3': return 'padding-top: 0.75rem; padding-bottom: 0.75rem;';
     case 'py-4': return 'padding-top: 1rem; padding-bottom: 1rem;';
     case 'pb-6': return 'padding-bottom: 1.5rem;';
+    case 'pl-2': return 'padding-left: 0.5rem;';
+    case 'pl-3': return 'padding-left: 0.75rem;';
     case 'pl-6': return 'padding-left: 1.5rem;';
+    case 'pl-11': return 'padding-left: 2.75rem;';
     case 'pt-20': return 'padding-top: 5rem;';
     case 'mx-auto': return 'margin-left: auto; margin-right: auto;';
     case 'mx-4': return 'margin-left: 1rem; margin-right: 1rem;';
@@ -404,15 +420,19 @@ function baseDeclaration(base) {
     case 'mt-24': return 'margin-top: 6rem;';
     case 'mb-4': return 'margin-bottom: 1rem;';
     case 'mb-6': return 'margin-bottom: 1.5rem;';
+    case 'ml-3': return 'margin-left: 0.75rem;';
+    case 'ml-auto': return 'margin-left: auto;';
     case 'min-h-[70vh]': return 'min-height: 70vh;';
     case 'w-full': return 'width: 100%;';
     case 'w-auto': return 'width: auto;';
     case 'w-64': return 'width: 16rem;';
     case 'w-10': return 'width: 2.5rem;';
+    case 'w-6': return 'width: 1.5rem;';
     case 'w-5': return 'width: 1.25rem;';
     case 'w-4': return 'width: 1rem;';
     case 'h-10': return 'height: 2.5rem;';
     case 'h-8': return 'height: 2rem;';
+    case 'h-6': return 'height: 1.5rem;';
     case 'h-5': return 'height: 1.25rem;';
     case 'h-4': return 'height: 1rem;';
     case 'h-full': return 'height: 100%;';
@@ -432,7 +452,11 @@ function baseDeclaration(base) {
     case 'border-dashed': return 'border-style: dashed;';
     case '-translate-x-full': return 'transform: translateX(-100%);';
     case 'transition': return 'transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);';
+    case 'transition-colors': return 'transition-property: color, background-color, border-color; transition-duration: 0.2s; transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);';
     case 'transition-transform': return 'transition-property: transform; transition-duration: 0.2s; transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);';
+    case 'duration-200': return 'transition-duration: 0.2s;';
+    case 'duration-300': return 'transition-duration: 0.3s;';
+    case 'ease-in-out': return 'transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);';
     case 'shadow-sm': return 'box-shadow: 0 1px 2px rgba(15, 23, 42, 0.05);';
     case 'shadow-xl': return 'box-shadow: 0 20px 25px -5px rgba(15, 23, 42, 0.1), 0 10px 10px -5px rgba(15, 23, 42, 0.04);';
     case 'font-medium': return 'font-weight: 500;';
@@ -441,6 +465,7 @@ function baseDeclaration(base) {
     case 'uppercase': return 'text-transform: uppercase;';
     case 'tracking-wide': return 'letter-spacing: 0.05em;';
     case 'tracking-widest': return 'letter-spacing: 0.1em;';
+    case 'text-left': return 'text-align: left;';
     case 'text-center': return 'text-align: center;';
     case 'text-right': return 'text-align: right;';
     case 'backdrop-blur': return 'backdrop-filter: blur(8px);';
@@ -457,6 +482,7 @@ function baseDeclaration(base) {
     case 'object-tools': return 'display: flex; gap: 0.5rem; list-style: none; margin: 0; padding: 0;';
     case 'changelist-form-container': return 'overflow-x: auto;';
     case 'cancel-link': return 'display: inline-block; margin-left: 1rem; color: #4b5563;';
+    case 'truncate': return 'overflow: hidden; text-overflow: ellipsis; white-space: nowrap;';
   }
   if (base.startsWith('grid-cols-[')) {
     const value = base.slice('grid-cols-['.length, -1);


### PR DESCRIPTION
## Summary
- restyle the admin dashboard link and app accordions to Flowbite Admin’s sidebar pattern with simplified icon treatments
- extend the CSS build script for additional utilities, add accordion caret rotation styling, and regenerate the compiled stylesheet

## Testing
- npm run build
- pytest *(fails: settings are not configured for the test suite in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0d0c70fc883268f97ce2f7c3e01de