### PR TITLE
Add Flowbite overrides for auth admin templates

### DIFF
--- a/flowbite_admin/templates/admin/auth/group/change_form.html
+++ b/flowbite_admin/templates/admin/auth/group/change_form.html
@@ -1,0 +1,4 @@
+{% extends "admin/change_form.html" %}
+{% load i18n %}
+
+{% block coltype %}colM mt-24 space-y-6 px-4 pb-12 sm:ml-64 sm:px-8{% endblock %}

--- a/flowbite_admin/templates/admin/auth/group/change_list.html
+++ b/flowbite_admin/templates/admin/auth/group/change_list.html
@@ -1,0 +1,4 @@
+{% extends "admin/change_list.html" %}
+{% load i18n %}
+
+{% block coltype %}colM mt-24 space-y-6 px-4 pb-12 sm:ml-64 sm:px-8{% endblock %}

--- a/flowbite_admin/templates/admin/auth/user/change_form.html
+++ b/flowbite_admin/templates/admin/auth/user/change_form.html
@@ -1,0 +1,16 @@
+{% extends "admin/change_form.html" %}
+{% load i18n admin_urls %}
+
+{% block coltype %}colM mt-24 space-y-6 px-4 pb-12 sm:ml-64 sm:px-8{% endblock %}
+
+{% block object-tools-items %}
+  {{ block.super }}
+  {% if change and not is_popup and has_change_permission %}
+    {% url opts|admin_urlname:'password_change' original.pk|admin_urlquote as password_url %}
+    <li>
+      <a href="{% add_preserved_filters password_url %}" class="passwordlink">
+        {% translate "Change password" %}
+      </a>
+    </li>
+  {% endif %}
+{% endblock %}

--- a/flowbite_admin/templates/admin/auth/user/change_list.html
+++ b/flowbite_admin/templates/admin/auth/user/change_list.html
@@ -1,0 +1,4 @@
+{% extends "admin/change_list.html" %}
+{% load i18n %}
+
+{% block coltype %}colM mt-24 space-y-6 px-4 pb-12 sm:ml-64 sm:px-8{% endblock %}

--- a/tests/test_admin_flowbite.py
+++ b/tests/test_admin_flowbite.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+from html.parser import HTMLParser
+
 from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Group
 from django.test import Client, TestCase
 from django.urls import reverse
 
@@ -17,6 +20,7 @@ class AdminFlowbiteTests(TestCase):
             email="admin@example.com",
             password=cls.password,
         )
+        cls.group = Group.objects.create(name="Flowbite Group")
         cls.book = Book.objects.create(title="The Flowbite Book", author="Tester")
 
     def setUp(self) -> None:
@@ -25,6 +29,24 @@ class AdminFlowbiteTests(TestCase):
     def login(self) -> None:
         logged_in = self.client.login(username=self.username, password=self.password)
         self.assertTrue(logged_in, "Failed to authenticate test client")
+
+    def assert_content_has_sidebar_offset(self, response) -> None:
+        class _ContentParser(HTMLParser):
+            def __init__(self) -> None:
+                super().__init__()
+                self.content_class: str | None = None
+
+            def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+                if self.content_class is not None or tag != "div":
+                    return
+                attr_map = dict(attrs)
+                if attr_map.get("id") == "content":
+                    self.content_class = attr_map.get("class", "")
+
+        parser = _ContentParser()
+        parser.feed(response.content.decode())
+        self.assertIsNotNone(parser.content_class, "Admin template is missing the #content container")
+        self.assertIn("sm:ml-64", parser.content_class or "", "#content should include the sidebar offset class")
 
     def test_login_page_renders_flowbite_styles(self) -> None:
         response = self.client.get(reverse("admin:login"))
@@ -54,6 +76,34 @@ class AdminFlowbiteTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "rounded-2xl border border-gray-200 bg-white")
         self.assertContains(response, "bg-white p-4 shadow-sm ring-1 ring-gray-100")
+
+    def test_user_changelist_has_sidebar_offset(self) -> None:
+        self.login()
+        response = self.client.get(reverse("admin:auth_user_changelist"))
+        self.assertEqual(response.status_code, 200)
+        self.assert_content_has_sidebar_offset(response)
+
+    def test_user_change_form_has_sidebar_offset_and_password_tool(self) -> None:
+        self.login()
+        url = reverse("admin:auth_user_change", args=[self.user.pk])
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assert_content_has_sidebar_offset(response)
+        password_url = reverse("admin:auth_user_password_change", args=[self.user.pk])
+        self.assertContains(response, password_url)
+
+    def test_group_changelist_has_sidebar_offset(self) -> None:
+        self.login()
+        response = self.client.get(reverse("admin:auth_group_changelist"))
+        self.assertEqual(response.status_code, 200)
+        self.assert_content_has_sidebar_offset(response)
+
+    def test_group_change_form_has_sidebar_offset(self) -> None:
+        self.login()
+        url = reverse("admin:auth_group_change", args=[self.group.pk])
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assert_content_has_sidebar_offset(response)
 
     def test_delete_confirmation_template_renders(self) -> None:
         self.login()


### PR DESCRIPTION
## Summary
- add Flowbite-scoped overrides for the Django auth user and group change views that keep Flowbite’s sidebar spacing classes
- retain Django’s change password object tool on the user change form while using the Flowbite layout scaffolding
- add regression tests that confirm the auth change list and form views render the sidebar offset class and the password-change link

## Testing
- DJANGO_SETTINGS_MODULE=tests.settings python -m django test

------
https://chatgpt.com/codex/tasks/task_e_68e0e89844ac832693370446d311949b