### PR TITLE
Ensure admin changelists inherit Flowbite layout spacing

### DIFF
--- a/flowbite_admin/templates/admin/auth/group/change_form.html
+++ b/flowbite_admin/templates/admin/auth/group/change_form.html
@@ -1,4 +1,1 @@
 {% extends "admin/change_form.html" %}
-{% load i18n %}
-
-{% block coltype %}colM mt-24 space-y-6 px-4 pb-12 sm:ml-64 sm:px-8{% endblock %}

--- a/flowbite_admin/templates/admin/auth/group/change_list.html
+++ b/flowbite_admin/templates/admin/auth/group/change_list.html
@@ -1,4 +1,1 @@
 {% extends "admin/change_list.html" %}
-{% load i18n %}
-
-{% block coltype %}colM mt-24 space-y-6 px-4 pb-12 sm:ml-64 sm:px-8{% endblock %}

--- a/flowbite_admin/templates/admin/auth/user/change_form.html
+++ b/flowbite_admin/templates/admin/auth/user/change_form.html
@@ -1,8 +1,6 @@
 {% extends "admin/change_form.html" %}
 {% load i18n admin_urls %}
 
-{% block coltype %}colM mt-24 space-y-6 px-4 pb-12 sm:ml-64 sm:px-8{% endblock %}
-
 {% block object-tools-items %}
   {{ block.super }}
   {% if change and not is_popup and has_change_permission %}

--- a/flowbite_admin/templates/admin/auth/user/change_list.html
+++ b/flowbite_admin/templates/admin/auth/user/change_list.html
@@ -1,4 +1,1 @@
 {% extends "admin/change_list.html" %}
-{% load i18n %}
-
-{% block coltype %}colM mt-24 space-y-6 px-4 pb-12 sm:ml-64 sm:px-8{% endblock %}

--- a/flowbite_admin/templates/admin/change_list.html
+++ b/flowbite_admin/templates/admin/change_list.html
@@ -42,7 +42,7 @@
   {% endblock %}
 {% endif %}
 
-{% block coltype %}{% endblock %}
+{% block coltype %}colM mt-24 space-y-6 px-4 pb-12 sm:ml-64 sm:px-8{% endblock %}
 
 {% block content %}
   <div id="content-main" class="space-y-6">


### PR DESCRIPTION
## Summary
- ensure the admin changelist template applies the Flowbite spacing classes to the content container
- remove redundant coltype overrides in the auth change list and change form templates so they inherit the shared layout

## Testing
- DJANGO_SETTINGS_MODULE=tests.settings python -m django test tests.test_admin_flowbite.AdminFlowbiteTests

------
https://chatgpt.com/codex/tasks/task_e_68e0faaaf2d083268eec5c8245fb1eff