### PR TITLE
Add profile and settings shortcuts to Flowbite admin menu

### DIFF
--- a/flowbite_admin/apps.py
+++ b/flowbite_admin/apps.py
@@ -1,6 +1,31 @@
+from types import MethodType
+
 from django.apps import AppConfig
+from django.contrib import admin
+
+from .sites import FlowbiteAdminSite, get_user_settings_urlpatterns
 
 
 class FlowbiteAdminConfig(AppConfig):
     default_auto_field = 'django.db.models.BigAutoField'
     name = 'flowbite_admin'
+
+    def ready(self) -> None:
+        """Ensure the default admin site exposes Flowbite user tools."""
+
+        site = admin.site
+
+        if isinstance(site, FlowbiteAdminSite):
+            return
+
+        if getattr(site, "_flowbite_user_settings_registered", False):
+            return
+
+        original_get_urls = site.get_urls
+
+        def get_urls(this_site):
+            urls = original_get_urls()
+            return get_user_settings_urlpatterns(this_site) + urls
+
+        site.get_urls = MethodType(get_urls, site)
+        setattr(site, "_flowbite_user_settings_registered", True)

--- a/flowbite_admin/sites.py
+++ b/flowbite_admin/sites.py
@@ -13,17 +13,33 @@ from django.db import OperationalError
 from django.db.models import Count
 from django.http import HttpRequest, HttpResponse, JsonResponse
 from django.template.response import TemplateResponse
-from django.urls import NoReverseMatch, reverse
+from django.urls import NoReverseMatch, path, reverse
 from django.utils import timezone
 from django.utils.formats import date_format
 from django.utils.timesince import timesince
 from django.utils.translation import gettext_lazy as _
+
+from .views import UserSettingsView
+
+
+def get_user_settings_urlpatterns(site: admin.AdminSite) -> list:
+    """Return URL patterns used to power the user settings screen."""
+
+    return [
+        path("settings/", site.admin_view(UserSettingsView.as_view()), name="user-settings"),
+    ]
 
 
 class FlowbiteAdminSite(admin.AdminSite):
     """Admin site that powers the Flowbite dashboard widgets."""
 
     widget_session_key = "flowbite_admin_widget_layout"
+
+    def get_urls(self):
+        """Extend default admin URLs with Flowbite-specific views."""
+
+        urls = super().get_urls()
+        return get_user_settings_urlpatterns(self) + urls
 
     def get_default_widget_layout(self, request: HttpRequest) -> List[str]:
         """Return the default order for dashboard widgets."""

--- a/flowbite_admin/templates/admin/base_site.html
+++ b/flowbite_admin/templates/admin/base_site.html
@@ -134,27 +134,16 @@
           </div>
           <ul class="list-none space-y-1 p-2 text-sm text-gray-700 dark:text-gray-200" data-user-menu-links>
             {% block userlinks %}
-              {% if site_url %}
-                <li>
-                  <a class="flex items-center justify-between rounded-lg px-3 py-2 font-medium text-gray-700 transition hover:bg-gray-100 hover:text-gray-900 dark:text-gray-200 dark:hover:bg-gray-700/70 dark:hover:text-white" href="{{ site_url }}">
-                    {% translate 'View site' %}
-                    <svg class="h-4 w-4 text-gray-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
-                      <path stroke-linecap="round" stroke-linejoin="round" d="M17.25 6.75L21 10.5m0 0l-3.75 3.75M21 10.5H9" />
-                      <path stroke-linecap="round" stroke-linejoin="round" d="M12 6.75H7.5A2.25 2.25 0 005.25 9v9A2.25 2.25 0 007.5 20.25h9A2.25 2.25 0 0018.75 18v-4.5" />
-                    </svg>
-                  </a>
-                </li>
-              {% endif %}
-              {% if user.is_active and user.is_staff %}
-                {% url 'django-admindocs-docroot' as docsroot %}
-                {% if docsroot %}
-                  <li>
-                    <a class="flex items-center rounded-lg px-3 py-2 font-medium text-gray-700 transition hover:bg-gray-100 hover:text-gray-900 dark:text-gray-200 dark:hover:bg-gray-700/70 dark:hover:text-white" href="{{ docsroot }}">
-                      {% translate 'Documentation' %}
-                    </a>
-                  </li>
-                {% endif %}
-              {% endif %}
+              <li>
+                <a class="flex items-center rounded-lg px-3 py-2 font-medium text-gray-700 transition hover:bg-gray-100 hover:text-gray-900 dark:text-gray-200 dark:hover:bg-gray-700/70 dark:hover:text-white" href="{% url 'admin:auth_user_change' user.pk %}">
+                  {% translate 'Profile' %}
+                </a>
+              </li>
+              <li>
+                <a class="flex items-center rounded-lg px-3 py-2 font-medium text-gray-700 transition hover:bg-gray-100 hover:text-gray-900 dark:text-gray-200 dark:hover:bg-gray-700/70 dark:hover:text-white" href="{% url 'admin:user-settings' %}">
+                  {% translate 'Settings' %}
+                </a>
+              </li>
               {% if user.has_usable_password %}
                 <li>
                   <a class="flex items-center rounded-lg px-3 py-2 font-medium text-gray-700 transition hover:bg-gray-100 hover:text-gray-900 dark:text-gray-200 dark:hover:bg-gray-700/70 dark:hover:text-white" href="{% url 'admin:password_change' %}">
@@ -174,6 +163,27 @@
                   </button>
                 </form>
               </li>
+              {% if site_url %}
+                <li class="border-t border-gray-100 pt-1 dark:border-gray-700">
+                  <a class="flex items-center justify-between rounded-lg px-3 py-2 font-medium text-gray-700 transition hover:bg-gray-100 hover:text-gray-900 dark:text-gray-200 dark:hover:bg-gray-700/70 dark:hover:text-white" href="{{ site_url }}">
+                    {% translate 'View site' %}
+                    <svg class="h-4 w-4 text-gray-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+                      <path stroke-linecap="round" stroke-linejoin="round" d="M17.25 6.75L21 10.5m0 0l-3.75 3.75M21 10.5H9" />
+                      <path stroke-linecap="round" stroke-linejoin="round" d="M12 6.75H7.5A2.25 2.25 0 005.25 9v9A2.25 2.25 0 007.5 20.25h9A2.25 2.25 0 0018.75 18v-4.5" />
+                    </svg>
+                  </a>
+                </li>
+              {% endif %}
+              {% if user.is_active and user.is_staff %}
+                {% url 'django-admindocs-docroot' as docsroot %}
+                {% if docsroot %}
+                  <li{% if not site_url %} class="border-t border-gray-100 pt-1 dark:border-gray-700"{% endif %}>
+                    <a class="flex items-center rounded-lg px-3 py-2 font-medium text-gray-700 transition hover:bg-gray-100 hover:text-gray-900 dark:text-gray-200 dark:hover:bg-gray-700/70 dark:hover:text-white" href="{{ docsroot }}">
+                      {% translate 'Documentation' %}
+                    </a>
+                  </li>
+                {% endif %}
+              {% endif %}
             {% endblock %}
           </ul>
         </div>

--- a/flowbite_admin/templates/admin/user_settings.html
+++ b/flowbite_admin/templates/admin/user_settings.html
@@ -1,0 +1,34 @@
+{% extends "admin/base_site.html" %}
+{% load i18n %}
+
+{% block title %}{{ title }} | {{ block.super }}{% endblock %}
+
+{% block breadcrumbs %}
+  <ol class="flex flex-wrap items-center gap-2 text-sm text-gray-500 dark:text-gray-400">
+    <li>
+      <a class="inline-flex items-center gap-1 rounded-lg px-3 py-1 font-medium text-gray-600 hover:bg-blue-50 hover:text-blue-700 dark:text-gray-300 dark:hover:bg-gray-800 dark:hover:text-white" href="{% url 'admin:index' %}">
+        {% translate 'Home' %}
+      </a>
+    </li>
+    <li aria-hidden="true" class="text-gray-400">/</li>
+    <li class="rounded-lg bg-blue-50 px-3 py-1 font-semibold text-blue-700 dark:bg-blue-500/20 dark:text-blue-200">
+      {% translate 'Settings' %}
+    </li>
+  </ol>
+{% endblock %}
+
+{% block content %}
+  <div id="content-main" class="space-y-6">
+    <section class="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+      <header class="space-y-1">
+        <p class="text-xs font-semibold uppercase tracking-[0.3em] text-gray-400 dark:text-gray-500">{% translate 'Account' %}</p>
+        <h1 class="text-2xl font-semibold text-gray-900 dark:text-white">{{ title }}</h1>
+        <p class="text-sm text-gray-600 dark:text-gray-300">{{ settings_description }}</p>
+      </header>
+      <div class="mt-6 space-y-4 text-sm text-gray-700 dark:text-gray-200">
+        <p>{% translate "This page is a placeholder for future personalization options such as notification preferences or saved layouts." %}</p>
+        <p>{% translate "You can adjust your profile information or change your password using the menu in the top-right corner." %}</p>
+      </div>
+    </section>
+  </div>
+{% endblock %}

--- a/flowbite_admin/views.py
+++ b/flowbite_admin/views.py
@@ -1,0 +1,22 @@
+"""Views for Flowbite admin customizations."""
+from __future__ import annotations
+
+from django.utils.translation import gettext_lazy as _
+from django.views.generic import TemplateView
+
+
+class UserSettingsView(TemplateView):
+    """Display lightweight user settings page within the admin."""
+
+    template_name = "admin/user_settings.html"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context.setdefault("title", _("Account settings"))
+        context.setdefault(
+            "settings_description",
+            _(
+                "Adjust admin preferences, shortcuts, and personal details to tailor the dashboard to your workflow."
+            ),
+        )
+        return context


### PR DESCRIPTION
## Summary
- add profile and settings entries to the account menu and keep optional links after the required actions
- provide a lightweight user settings view/template and register its URL on Flowbite and default admin sites
- hook the default Django admin site during app setup so the new menu item always resolves

## Testing
- DJANGO_SETTINGS_MODULE=tests.settings python -m django test

------
https://chatgpt.com/codex/tasks/task_e_68e108aadca4832680cdb4250aadace1