### PR TITLE
Fix advanced filter form nesting in change list template

### DIFF
--- a/flowbite_admin/templates/admin/change_list.html
+++ b/flowbite_admin/templates/admin/change_list.html
@@ -78,67 +78,67 @@
           </div>
         </div>
 
-        <div class="rounded-2xl border border-gray-200 bg-white shadow-sm dark:border-gray-700 dark:bg-gray-800">
-          <div class="changelist-form-container space-y-4 overflow-hidden">
-            {% if cl.advanced_filter_form %}
-              {% with advanced_form=cl.advanced_filter_form %}
-                {% with advanced_open=advanced_form.is_bound %}
-                  <div class="rounded-2xl border border-gray-200 bg-white shadow-sm dark:border-gray-700 dark:bg-gray-800">
-                    <div class="border-b border-gray-200 px-4 py-2 dark:border-gray-700">
-                      <div id="advanced-filter-accordion" data-accordion="collapse" data-active-classes="bg-gray-50 dark:bg-gray-900/40 text-gray-900 dark:text-white">
-                        <h2 id="advanced-filter-heading">
-                          <button type="button" class="flex w-full items-center justify-between gap-2 rounded-lg px-2 py-2 text-left text-sm font-semibold text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:text-gray-200 dark:hover:bg-gray-900/60" data-accordion-target="#advanced-filter-body" aria-expanded="{{ advanced_open|yesno:'true,false' }}" aria-controls="advanced-filter-body">
-                            <span>{% translate "Advanced filters" %}</span>
-                            <svg data-accordion-icon class="h-5 w-5 shrink-0 text-gray-500 transition-transform duration-200" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-                              <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
-                            </svg>
-                          </button>
-                        </h2>
-                        <div id="advanced-filter-body" class="{% if not advanced_open %}hidden{% endif %}" aria-labelledby="advanced-filter-heading">
-                          <div class="space-y-4 px-2 py-4">
-                            <form id="advanced-filter-form" method="get" class="space-y-4">
-                              {% for hidden in advanced_form.hidden_fields %}
-                                {{ hidden }}
-                                {% if hidden.errors %}
-                                  <p class="text-xs text-red-600 dark:text-red-400">{{ hidden.errors|striptags }}</p>
+        {% if cl.advanced_filter_form %}
+          {% with advanced_form=cl.advanced_filter_form %}
+            {% with advanced_open=advanced_form.is_bound %}
+              <div class="rounded-2xl border border-gray-200 bg-white shadow-sm dark:border-gray-700 dark:bg-gray-800">
+                <div class="border-b border-gray-200 px-4 py-2 dark:border-gray-700">
+                  <div id="advanced-filter-accordion" data-accordion="collapse" data-active-classes="bg-gray-50 dark:bg-gray-900/40 text-gray-900 dark:text-white">
+                    <h2 id="advanced-filter-heading">
+                      <button type="button" class="flex w-full items-center justify-between gap-2 rounded-lg px-2 py-2 text-left text-sm font-semibold text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:text-gray-200 dark:hover:bg-gray-900/60" data-accordion-target="#advanced-filter-body" aria-expanded="{{ advanced_open|yesno:'true,false' }}" aria-controls="advanced-filter-body">
+                        <span>{% translate "Advanced filters" %}</span>
+                        <svg data-accordion-icon class="h-5 w-5 shrink-0 text-gray-500 transition-transform duration-200" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                          <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
+                        </svg>
+                      </button>
+                    </h2>
+                    <div id="advanced-filter-body" class="{% if not advanced_open %}hidden{% endif %}" aria-labelledby="advanced-filter-heading">
+                      <div class="space-y-4 px-2 py-4">
+                        <form id="advanced-filter-form" method="get" class="space-y-4">
+                          {% for hidden in advanced_form.hidden_fields %}
+                            {{ hidden }}
+                            {% if hidden.errors %}
+                              <p class="text-xs text-red-600 dark:text-red-400">{{ hidden.errors|striptags }}</p>
+                            {% endif %}
+                          {% endfor %}
+                          {% for key, value in cl.advanced_filter_preserved_params %}
+                            <input type="hidden" name="{{ key }}" value="{{ value }}">
+                          {% endfor %}
+                          {% if advanced_form.non_field_errors %}
+                            <div class="rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-700 dark:border-red-900/50 dark:bg-red-900/30 dark:text-red-200">
+                              {{ advanced_form.non_field_errors }}
+                            </div>
+                          {% endif %}
+                          <div class="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+                            {% for field in advanced_form.visible_fields %}
+                              <div>
+                                <label for="{{ field.id_for_label }}" class="mb-1 block text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">{{ field.label }}</label>
+                                {{ field }}
+                                {% if field.help_text %}
+                                  <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">{{ field.help_text }}</p>
                                 {% endif %}
-                              {% endfor %}
-                              {% for key, value in cl.advanced_filter_preserved_params %}
-                                <input type="hidden" name="{{ key }}" value="{{ value }}">
-                              {% endfor %}
-                              {% if advanced_form.non_field_errors %}
-                                <div class="rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-700 dark:border-red-900/50 dark:bg-red-900/30 dark:text-red-200">
-                                  {{ advanced_form.non_field_errors }}
-                                </div>
-                              {% endif %}
-                              <div class="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
-                                {% for field in advanced_form.visible_fields %}
-                                  <div>
-                                    <label for="{{ field.id_for_label }}" class="mb-1 block text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">{{ field.label }}</label>
-                                    {{ field }}
-                                    {% if field.help_text %}
-                                      <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">{{ field.help_text }}</p>
-                                    {% endif %}
-                                    {% if field.errors %}
-                                      <p class="mt-1 text-xs text-red-600 dark:text-red-400">{{ field.errors|striptags }}</p>
-                                    {% endif %}
-                                  </div>
-                                {% endfor %}
+                                {% if field.errors %}
+                                  <p class="mt-1 text-xs text-red-600 dark:text-red-400">{{ field.errors|striptags }}</p>
+                                {% endif %}
                               </div>
-                              <div class="flex flex-wrap items-center justify-end gap-2">
-                                <a href="{{ cl.advanced_filter_reset_query }}" class="inline-flex items-center rounded-lg border border-gray-200 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 dark:border-gray-700 dark:text-gray-200 dark:hover:bg-gray-900/60">{% translate "Reset" %}</a>
-                                <button type="submit" form="advanced-filter-form" class="inline-flex items-center rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900">{% translate "Apply filters" %}</button>
-                              </div>
-                            </form>
+                            {% endfor %}
                           </div>
-                        </div>
+                          <div class="flex flex-wrap items-center justify-end gap-2">
+                            <a href="{{ cl.advanced_filter_reset_query }}" class="inline-flex items-center rounded-lg border border-gray-200 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 dark:border-gray-700 dark:text-gray-200 dark:hover:bg-gray-900/60">{% translate "Reset" %}</a>
+                            <button type="submit" form="advanced-filter-form" class="inline-flex items-center rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900">{% translate "Apply filters" %}</button>
+                          </div>
+                        </form>
                       </div>
                     </div>
                   </div>
-                {% endwith %}
-              {% endwith %}
-            {% endif %}
+                </div>
+              </div>
+            {% endwith %}
+          {% endwith %}
+        {% endif %}
 
+        <div class="rounded-2xl border border-gray-200 bg-white shadow-sm dark:border-gray-700 dark:bg-gray-800">
+          <div class="changelist-form-container space-y-4 overflow-hidden">
             <form id="changelist-form" method="post"{% if cl.formset and cl.formset.is_multipart %} enctype="multipart/form-data"{% endif %} novalidate>
               {% csrf_token %}
               {% if cl.formset %}


### PR DESCRIPTION
## Summary
- move the advanced filter GET form outside the changelist POST form while preserving preserved parameters
- keep the POST form around the result list and actions
- add regression tests covering form placement and bulk action behaviour

## Testing
- pytest tests/test_admin_flowbite.py

------
https://chatgpt.com/codex/tasks/task_e_68e15e34c4488326899eaa92a394ec15