### PR TITLE
Remove legacy login stylesheet dependency

### DIFF
--- a/flowbite_admin/templates/admin/login.html
+++ b/flowbite_admin/templates/admin/login.html
@@ -5,7 +5,6 @@
 
 {% block extrastyle %}
   {{ block.super }}
-  <link rel="stylesheet" href="{% static 'admin/css/login.css' %}">
   {{ form.media }}
 {% endblock %}
 
@@ -51,12 +50,24 @@
 
       <form action="{{ app_path }}" method="post" id="login-form" class="space-y-4">{% csrf_token %}
         <div class="space-y-1">
-          {{ form.username.errors }}
+          {% if form.username.errors %}
+            <ul class="list-none space-y-1">
+              {% for error in form.username.errors %}
+                <li class="text-sm font-medium text-red-600 dark:text-red-400">{{ error }}</li>
+              {% endfor %}
+            </ul>
+          {% endif %}
           <label for="{{ form.username.id_for_label }}" class="block text-sm font-medium text-gray-700 dark:text-gray-200">{{ form.username.label }}</label>
           {% render_field form.username class="w-full rounded-lg border border-gray-300 bg-gray-50 p-3 text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white" %}
         </div>
         <div class="space-y-1">
-          {{ form.password.errors }}
+          {% if form.password.errors %}
+            <ul class="list-none space-y-1">
+              {% for error in form.password.errors %}
+                <li class="text-sm font-medium text-red-600 dark:text-red-400">{{ error }}</li>
+              {% endfor %}
+            </ul>
+          {% endif %}
           <label for="{{ form.password.id_for_label }}" class="block text-sm font-medium text-gray-700 dark:text-gray-200">{{ form.password.label }}</label>
           {% render_field form.password class="w-full rounded-lg border border-gray-300 bg-gray-50 p-3 text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white" %}
           <input type="hidden" name="next" value="{{ next }}">


### PR DESCRIPTION
## Summary
- drop the legacy Django admin login stylesheet from the Flowbite login template
- restyle field error messages with Tailwind utility classes to retain Flowbite look and feel

## Testing
- python -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68e17377f538832688298c51aef6927e